### PR TITLE
feat: add scalar formats and @Required, fix value-restriction annotat…

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,14 @@ References are NOT supported:
     - google/protobuf/*
     - google/type/*
 
+## Scalar type formats
+
+Each protobuf scalar type is mapped to a JSON schema `type` plus a `format` that preserves the
+original protobuf wire type. For example `int64` becomes `{"type": "integer", "format": "int64"}`
+and `bytes` becomes `{"type": "string", "format": "bytes"}`. The protobuf type is additionally kept
+in the non-standard `x-primitive` keyword. By default numeric types also carry `minimum`/`maximum`
+limits (see the `primitiveTypesWithLimits` option).
+
 ## Comments
 
 Each field of a message may have a comment witch will be reflected as json schema `description`.
@@ -140,6 +148,7 @@ message Point {
 | @MinItems            | json scheme [array validator](https://json-schema.org/understanding-json-schema/reference/array#length)	                             |
 | @MaxItems            | json scheme [array validator](https://json-schema.org/understanding-json-schema/reference/array#length)		                            |
 | @Default             | json schema [default value](https://opis.io/json-schema/1.x/default-value.html)	                                                     |
+| @Required            | adds the field to the json schema `required` list. Additive: a field is required if it is proto2 `required`, a non-optional proto3 field, or annotated with `@Required` |
 
 ### Per message annotation
 

--- a/src/primitive-types.ts
+++ b/src/primitive-types.ts
@@ -14,6 +14,7 @@ export class PrimitiveTypes {
   public static readonly PRIMITIVE_TYPES_WITH_LIMITS: AsyncApiTypeMap = {
     bytes: {
       type: 'string',
+      format: 'bytes',
       'x-primitive': 'bytes',
     },
     string: {
@@ -26,126 +27,93 @@ export class PrimitiveTypes {
     },
     int32: {
       type: 'integer',
+      format: 'int32',
       minimum: -0x80000000,
       maximum: 0x7fffffff,
       'x-primitive': 'int32',
     },
     sint32: {
       type: 'integer',
+      format: 'sint32',
       minimum: -0x80000000,
       maximum: 0x7fffffff,
       'x-primitive': 'sint32',
     },
     uint32: {
       type: 'integer',
+      format: 'uint32',
       minimum: 0,
       maximum: 0xffffffff,
       'x-primitive': 'uint32',
     },
     int64: {
       type: 'integer',
+      format: 'int64',
       minimum: this.MIN_SAFE_INTEGER,
       maximum: this.MAX_SAFE_INTEGER,
       'x-primitive': 'int64',
     },
     sint64: {
       type: 'integer',
+      format: 'sint64',
       minimum: this.MIN_SAFE_INTEGER,
       maximum: this.MAX_SAFE_INTEGER,
       'x-primitive': 'sint64',
     },
     uint64: {
       type: 'integer',
+      format: 'uint64',
       minimum: 0,
       maximum: this.MAX_SAFE_INTEGER,
       'x-primitive': 'uint64',
     },
     fixed32: {
       type: 'number',
+      format: 'fixed32',
       'x-primitive': 'fixed32',
     },
     fixed64: {
       type: 'number',
+      format: 'fixed64',
       'x-primitive': 'fixed64',
     },
     sfixed32: {
       type: 'number',
+      format: 'sfixed32',
       'x-primitive': 'sfixed32',
     },
     sfixed64: {
       type: 'number',
+      format: 'sfixed64',
       'x-primitive': 'sfixed64',
     },
     float: {
       type: 'number',
+      format: 'float',
       'x-primitive': 'float',
     },
     double: {
       type: 'number',
+      format: 'double',
       'x-primitive': 'double',
     },
   };
 
-  public static readonly PRIMITIVE_TYPES_MINIMAL: AsyncApiTypeMap = {
-    bytes: {
-      type: 'string',
-      'x-primitive': 'bytes',
-    },
-    string: {
-      type: 'string',
-      'x-primitive': 'string',
-    },
-    bool: {
-      type: 'boolean',
-      'x-primitive': 'bool',
-    },
-    int32: {
-      type: 'integer',
-      'x-primitive': 'int32',
-    },
-    sint32: {
-      type: 'integer',
-      'x-primitive': 'sint32',
-    },
-    uint32: {
-      type: 'integer',
-      'x-primitive': 'uint32',
-    },
-    int64: {
-      type: 'integer',
-      'x-primitive': 'int64',
-    },
-    sint64: {
-      type: 'integer',
-      'x-primitive': 'sint64',
-    },
-    uint64: {
-      type: 'integer',
-      'x-primitive': 'uint64',
-    },
-    fixed32: {
-      type: 'number',
-      'x-primitive': 'fixed32',
-    },
-    fixed64: {
-      type: 'number',
-      'x-primitive': 'fixed64',
-    },
-    sfixed32: {
-      type: 'number',
-      'x-primitive': 'sfixed32',
-    },
-    sfixed64: {
-      type: 'number',
-      'x-primitive': 'sfixed64',
-    },
-    float: {
-      type: 'number',
-      'x-primitive': 'float',
-    },
-    double: {
-      type: 'number',
-      'x-primitive': 'double',
-    },
-  };
+  /**
+   * Same as PRIMITIVE_TYPES_WITH_LIMITS but without the numeric `minimum`/`maximum`
+   * range limits. Derived from the map above to avoid duplicating every entry.
+   */
+  public static readonly PRIMITIVE_TYPES_MINIMAL: AsyncApiTypeMap =
+    PrimitiveTypes.withoutRangeLimits(PrimitiveTypes.PRIMITIVE_TYPES_WITH_LIMITS);
+
+  private static withoutRangeLimits(types: AsyncApiTypeMap): AsyncApiTypeMap {
+    const minimal: AsyncApiTypeMap = {};
+    for (const name of Object.keys(types)) {
+      const definition = {...(types[name] as Record<string, unknown>)};
+      delete definition.minimum;
+      delete definition.maximum;
+      minimal[name] = definition as AsyncAPISchemaDefinition;
+    }
+    return minimal;
+  }
 }

--- a/src/protoj2jsonSchema.ts
+++ b/src/protoj2jsonSchema.ts
@@ -32,7 +32,7 @@ class Proto2JsonSchema {
   }
 
   private parseOptionsAnnotation(rawSchema: string) {
-    const regex = /\s*(\/\/|\*)\s*@Option\s+(?<key>\w{1,50})\s+(?<value>[^\r\n]{1,200})/g;
+    const regex = /(\/\/|\*)\s*@Option\s+(?<key>\w{1,50})\s+(?<value>\S[^\r\n]{0,199})/g;
     let m: RegExpExecArray | null;
     while ((m = regex.exec(rawSchema)) !== null) {
       // This is necessary to avoid infinite loops with zero-width matches
@@ -218,6 +218,10 @@ class Proto2JsonSchema {
     return (field.options?.proto3_optional !== true && this.isProto3());
   }
 
+  private hasRequiredAnnotation(comment: string | null): boolean {
+    return comment !== null && (/@Required\b/i).test(comment);
+  }
+
   /**
    * Compiles a protobuf message to JSON schema
    */
@@ -253,7 +257,7 @@ class Proto2JsonSchema {
         continue;
       }
 
-      if (field.required || this.isProto3Required(field)) {
+      if (field.required || this.isProto3Required(field) || this.hasRequiredAnnotation(field.comment)) {
         obj.required?.push(fieldName);
       }
 
@@ -269,14 +273,14 @@ class Proto2JsonSchema {
         }
 
         if (field.comment) {
-          const minItemsPattern = /@minItems\\s(\\d+?)/i;
-          const maxItemsPattern = /@maxItems\\s(\\d+?)/i;
+          const minItemsPattern = /@MinItems\s(\d+)/i;
+          const maxItemsPattern = /@MaxItems\s(\d+)/i;
           let m: RegExpExecArray | null;
           if ((m = minItemsPattern.exec(field.comment)) !== null) {
-            obj.minItems = parseFloat(m[1]);
+            properties[field.name].minItems = Number.parseInt(m[1], 10);
           }
           if ((m = maxItemsPattern.exec(field.comment)) !== null) {
-            obj.maxItems = parseFloat(m[1]);
+            properties[field.name].maxItems = Number.parseInt(m[1], 10);
           }
         }
 
@@ -398,7 +402,9 @@ class Proto2JsonSchema {
       .replace(new RegExp(`\\s{0,15}${COMMENT_DEFAULT}\\s{0,15}(.+)`, 'ig'), '')
       .replace(new RegExp(`\\s{0,15}${COMMENT_OPTION}\\s{0,15}(.+)`, 'ig'), '')
       .replace(new RegExp(`\\s{0,15}${COMMENT_ROOT_NODE}`, 'ig'), '')
-      .replace(new RegExp('\\s{0,15}@(Min|Max|Pattern|Minimum|Maximum|ExclusiveMinimum|ExclusiveMaximum|MultipleOf|MaxLength|MinLength|MaxItems|MinItems)\\s{0,15}[\\d.]{1,20}', 'ig'), '')
+      .replace(/\s{0,15}@Required/ig, '')
+      .replace(/\s{0,15}@Pattern\s{0,15}[^\r\n]{1,200}/ig, '')
+      .replace(/\s{0,15}@(Min|Max|Minimum|Maximum|ExclusiveMinimum|ExclusiveMaximum|MultipleOf|MaxLength|MinLength|MaxItems|MinItems)\s{0,15}[\d.]{1,20}/ig, '')
       .trim();
 
     if (comment.length < 1) {
@@ -439,16 +445,16 @@ class Proto2JsonSchema {
 
     const patternMin = /@Min\s([+-]?\d+(\.\d+)?)/i;
     const patternMax = /@Max\s([+-]?\d+(\.\d+)?)/i;
-    const patternPattern = /@Pattern\\s([^\n]+)/i;
+    const patternPattern = /@Pattern\s([^\n]+)/i;
 
     const patterns = new Map<string, RegExp>([
-      ['minimum', /@Minimum\\s([+-]?\\d+(\\.\\d+)?)/i],
-      ['maximum', /@Maximum\\s([+-]?\\d+(\\.\\d+)?)/i],
-      ['exclusiveMinimum', /@ExclusiveMinimum\\s(\\d+(\\.\\d+)?)/i],
-      ['exclusiveMaximum', /@ExclusiveMaximum\\s(\\d+(\\.\\d+)?)/i],
-      ['multipleOf', /@MultipleOf\\s(\\d+(\\.\\d+)?)/i],
-      ['maxLength', /@MultipleOf\\s(\\d+(\\.\\d+)?)/i],
-      ['minLength', /@MultipleOf\\s(\\d+(\\.\\d+)?)/i],
+      ['minimum', /@Minimum\s([+-]?\d+(\.\d+)?)/i],
+      ['maximum', /@Maximum\s([+-]?\d+(\.\d+)?)/i],
+      ['exclusiveMinimum', /@ExclusiveMinimum\s([+-]?\d+(\.\d+)?)/i],
+      ['exclusiveMaximum', /@ExclusiveMaximum\s([+-]?\d+(\.\d+)?)/i],
+      ['multipleOf', /@MultipleOf\s(\d+(\.\d+)?)/i],
+      ['maxLength', /@MaxLength\s(\d+)/i],
+      ['minLength', /@MinLength\s(\d+)/i],
     ]);
 
     let m: RegExpExecArray | null;
@@ -462,7 +468,7 @@ class Proto2JsonSchema {
     }
 
     if ((m = patternPattern.exec(comment)) !== null) {
-      obj.pattern = m[1];
+      obj.pattern = m[1].trim();
     }
 
     for (const e of patterns.entries()) {

--- a/test/documents/comments.proto.result.json
+++ b/test/documents/comments.proto.result.json
@@ -28,12 +28,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -56,12 +58,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -125,12 +129,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
@@ -153,12 +159,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"

--- a/test/documents/complex.proto3.result.json
+++ b/test/documents/complex.proto3.result.json
@@ -34,6 +34,7 @@
                   "properties": {
                     "year": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 9999,
                       "x-primitive": "int32",
@@ -41,6 +42,7 @@
                     },
                     "month": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 12,
                       "x-primitive": "int32",
@@ -48,6 +50,7 @@
                     },
                     "day": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 31,
                       "x-primitive": "int32",
@@ -66,12 +69,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -94,6 +99,7 @@
                   "properties": {
                     "year": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 9999,
                       "x-primitive": "int32",
@@ -101,6 +107,7 @@
                     },
                     "month": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 12,
                       "x-primitive": "int32",
@@ -108,6 +115,7 @@
                     },
                     "day": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 31,
                       "x-primitive": "int32",
@@ -115,6 +123,7 @@
                     },
                     "hours": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 23,
                       "x-primitive": "int32",
@@ -122,6 +131,7 @@
                     },
                     "minutes": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 59,
                       "x-primitive": "int32",
@@ -129,6 +139,7 @@
                     },
                     "seconds": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 60,
                       "x-primitive": "int32",
@@ -136,6 +147,7 @@
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": 0,
                       "maximum": 999999999,
                       "x-primitive": "int32",
@@ -153,6 +165,7 @@
                           "properties": {
                             "seconds": {
                               "type": "integer",
+                              "format": "int64",
                               "minimum": -9007199254740991,
                               "maximum": 9007199254740991,
                               "x-primitive": "int64",
@@ -160,6 +173,7 @@
                             },
                             "nanos": {
                               "type": "integer",
+                              "format": "int32",
                               "minimum": -2147483648,
                               "maximum": 2147483647,
                               "x-primitive": "int32",
@@ -229,6 +243,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -246,12 +261,14 @@
                   "properties": {
                     "from": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
                     },
                     "to": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -474,6 +491,7 @@
                 "properties": {
                   "year": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 9999,
                     "x-primitive": "int32",
@@ -481,6 +499,7 @@
                   },
                   "month": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 12,
                     "x-primitive": "int32",
@@ -488,6 +507,7 @@
                   },
                   "day": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 31,
                     "x-primitive": "int32",
@@ -506,12 +526,14 @@
                 "properties": {
                   "seconds": {
                     "type": "integer",
+                    "format": "int64",
                     "minimum": -9007199254740991,
                     "maximum": 9007199254740991,
                     "x-primitive": "int64"
                   },
                   "nanos": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -534,6 +556,7 @@
                 "properties": {
                   "year": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 9999,
                     "x-primitive": "int32",
@@ -541,6 +564,7 @@
                   },
                   "month": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 12,
                     "x-primitive": "int32",
@@ -548,6 +572,7 @@
                   },
                   "day": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 31,
                     "x-primitive": "int32",
@@ -555,6 +580,7 @@
                   },
                   "hours": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 23,
                     "x-primitive": "int32",
@@ -562,6 +588,7 @@
                   },
                   "minutes": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 59,
                     "x-primitive": "int32",
@@ -569,6 +596,7 @@
                   },
                   "seconds": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 60,
                     "x-primitive": "int32",
@@ -576,6 +604,7 @@
                   },
                   "nanos": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": 0,
                     "maximum": 999999999,
                     "x-primitive": "int32",
@@ -593,6 +622,7 @@
                         "properties": {
                           "seconds": {
                             "type": "integer",
+                            "format": "int64",
                             "minimum": -9007199254740991,
                             "maximum": 9007199254740991,
                             "x-primitive": "int64",
@@ -600,6 +630,7 @@
                           },
                           "nanos": {
                             "type": "integer",
+                            "format": "int32",
                             "minimum": -2147483648,
                             "maximum": 2147483647,
                             "x-primitive": "int32",
@@ -669,6 +700,7 @@
                 "properties": {
                   "value": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -686,12 +718,14 @@
                 "properties": {
                   "from": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "to": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -910,6 +944,7 @@
               "properties": {
                 "year": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 9999,
                   "x-primitive": "int32",
@@ -917,6 +952,7 @@
                 },
                 "month": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 12,
                   "x-primitive": "int32",
@@ -924,6 +960,7 @@
                 },
                 "day": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 31,
                   "x-primitive": "int32",
@@ -942,12 +979,14 @@
               "properties": {
                 "seconds": {
                   "type": "integer",
+                  "format": "int64",
                   "minimum": -9007199254740991,
                   "maximum": 9007199254740991,
                   "x-primitive": "int64"
                 },
                 "nanos": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
@@ -970,6 +1009,7 @@
               "properties": {
                 "year": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 9999,
                   "x-primitive": "int32",
@@ -977,6 +1017,7 @@
                 },
                 "month": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 12,
                   "x-primitive": "int32",
@@ -984,6 +1025,7 @@
                 },
                 "day": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 31,
                   "x-primitive": "int32",
@@ -991,6 +1033,7 @@
                 },
                 "hours": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 23,
                   "x-primitive": "int32",
@@ -998,6 +1041,7 @@
                 },
                 "minutes": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 59,
                   "x-primitive": "int32",
@@ -1005,6 +1049,7 @@
                 },
                 "seconds": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 60,
                   "x-primitive": "int32",
@@ -1012,6 +1057,7 @@
                 },
                 "nanos": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": 0,
                   "maximum": 999999999,
                   "x-primitive": "int32",
@@ -1029,6 +1075,7 @@
                       "properties": {
                         "seconds": {
                           "type": "integer",
+                          "format": "int64",
                           "minimum": -9007199254740991,
                           "maximum": 9007199254740991,
                           "x-primitive": "int64",
@@ -1036,6 +1083,7 @@
                         },
                         "nanos": {
                           "type": "integer",
+                          "format": "int32",
                           "minimum": -2147483648,
                           "maximum": 2147483647,
                           "x-primitive": "int32",
@@ -1105,6 +1153,7 @@
               "properties": {
                 "value": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
@@ -1122,12 +1171,14 @@
               "properties": {
                 "from": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "to": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"

--- a/test/documents/protoc-gen-validate.result.json
+++ b/test/documents/protoc-gen-validate.result.json
@@ -41,12 +41,14 @@
                 "properties": {
                   "na": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "const": 1.23,
                     "description": "x must equal 1.23 exactly"
                   },
                   "nb": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "x-primitive": "int32",
                     "exclusiveMaximum": 10,
@@ -54,6 +56,7 @@
                   },
                   "nc": {
                     "type": "integer",
+                    "format": "uint64",
                     "minimum": 20,
                     "maximum": 9007199254740991,
                     "x-primitive": "uint64",
@@ -61,6 +64,7 @@
                   },
                   "nd": {
                     "type": "number",
+                    "format": "fixed32",
                     "x-primitive": "fixed32",
                     "minimum": 30,
                     "exclusiveMaximum": 40,
@@ -68,6 +72,7 @@
                   },
                   "ne": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "exclusiveMaximum": 30,
                     "minimum": 40,
@@ -75,6 +80,7 @@
                   },
                   "nf": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "exclusiveMaximum": 30,
                     "minimum": 40,
@@ -82,6 +88,7 @@
                   },
                   "ng": {
                     "type": "integer",
+                    "format": "uint32",
                     "minimum": 0,
                     "maximum": 4294967295,
                     "x-primitive": "uint32",
@@ -103,6 +110,7 @@
                   },
                   "nh": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "not": {
                       "oneOf": [
@@ -120,6 +128,7 @@
                   },
                   "ni": {
                     "type": "integer",
+                    "format": "uint32",
                     "minimum": 200,
                     "maximum": 4294967295,
                     "x-primitive": "uint32",
@@ -404,18 +413,21 @@
                 "properties": {
                   "ba": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "const": "foo",
                     "description": "x must be set to \"foo\" (\"\\x66\\x6f\\x6f\")"
                   },
                   "bb": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "const": "f09028bc",
                     "description": "x must be set to \"\\xf0\\x90\\x28\\xbc\""
                   },
                   "bc": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 3,
                     "maxLength": 3,
@@ -423,12 +435,14 @@
                   },
                   "bd": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 3,
                     "description": "x must be at least 3 bytes long"
                   },
                   "be": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 5,
                     "maxLength": 10,
@@ -436,30 +450,35 @@
                   },
                   "bf": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": "^[00-7F]+$",
                     "description": "x must be a non-empty, ASCII byte sequence"
                   },
                   "bg": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": "^99.*",
                     "description": "x must begin with \"\\x99\""
                   },
                   "bh": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": ".*buz7a$",
                     "description": "x must end with \"buz\\x7a\""
                   },
                   "bi": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": ".*baz.*",
                     "description": "x must contain \"baz\" anywhere inside it"
                   },
                   "bj": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "oneOf": [
                       {
@@ -479,6 +498,7 @@
                   },
                   "bk": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "not": {
                       "oneOf": [
@@ -496,6 +516,7 @@
                   },
                   "bl": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "oneOf": [
                       {
@@ -514,6 +535,7 @@
                   },
                   "bm": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "anyOf": [
                       {
@@ -529,14 +551,14 @@
                   },
                   "bn": {
                     "type": "string",
-                    "x-primitive": "bytes",
                     "format": "ipv4",
+                    "x-primitive": "bytes",
                     "description": "x must be a valid IPv4 address in byte format\neg: \"\\xC0\\xA8\\x00\\x01\""
                   },
                   "bo": {
                     "type": "string",
-                    "x-primitive": "bytes",
                     "format": "ipv6",
+                    "x-primitive": "bytes",
                     "description": "x must be a valid IPv6 address in byte format\neg: \"\\x20\\x01\\x0D\\xB8\\x85\\xA3\\x00\\x00\\x00\\x00\\x8A\\x2E\\x03\\x70\\x73\\x34\""
                   }
                 },
@@ -567,6 +589,7 @@
                     "type": "array",
                     "items": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32",
@@ -589,6 +612,7 @@
                       "properties": {
                         "id": {
                           "type": "integer",
+                          "format": "uint64",
                           "maximum": 9007199254740991,
                           "x-primitive": "uint64",
                           "exclusiveMinimum": 999
@@ -614,12 +638,14 @@
                           "properties": {
                             "lat": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -90,
                               "maximum": 90
                             },
                             "lng": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -180,
                               "maximum": 180
@@ -639,6 +665,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "double",
                       "x-primitive": "double",
                       "description": "x must contain exactly 7 elements"
                     },
@@ -650,6 +677,7 @@
                     "type": "array",
                     "items": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64",
@@ -662,6 +690,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "float",
                       "x-primitive": "float",
                       "description": "x must contain positive float values",
                       "exclusiveMinimum": 0
@@ -682,6 +711,7 @@
                       "properties": {
                         "id": {
                           "type": "integer",
+                          "format": "uint64",
                           "maximum": 9007199254740991,
                           "x-primitive": "uint64",
                           "exclusiveMinimum": 999
@@ -707,12 +737,14 @@
                           "properties": {
                             "lat": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -90,
                               "maximum": 90
                             },
                             "lng": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -180,
                               "maximum": 180
@@ -730,6 +762,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "float",
                       "x-primitive": "float",
                       "description": "x must contain positive float values",
                       "exclusiveMinimum": 0
@@ -750,6 +783,7 @@
                       "properties": {
                         "id": {
                           "type": "integer",
+                          "format": "uint64",
                           "maximum": 9007199254740991,
                           "x-primitive": "uint64",
                           "exclusiveMinimum": 999
@@ -775,12 +809,14 @@
                           "properties": {
                             "lat": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -90,
                               "maximum": 90
                             },
                             "lng": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -180,
                               "maximum": 180
@@ -828,6 +864,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -847,12 +884,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -871,12 +910,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -895,12 +936,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -919,12 +962,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -943,12 +988,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -967,12 +1014,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -991,12 +1040,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -1015,12 +1066,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -1075,12 +1128,14 @@
               "properties": {
                 "na": {
                   "type": "number",
+                  "format": "float",
                   "x-primitive": "float",
                   "const": 1.23,
                   "description": "x must equal 1.23 exactly"
                 },
                 "nb": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "x-primitive": "int32",
                   "exclusiveMaximum": 10,
@@ -1088,6 +1143,7 @@
                 },
                 "nc": {
                   "type": "integer",
+                  "format": "uint64",
                   "minimum": 20,
                   "maximum": 9007199254740991,
                   "x-primitive": "uint64",
@@ -1095,6 +1151,7 @@
                 },
                 "nd": {
                   "type": "number",
+                  "format": "fixed32",
                   "x-primitive": "fixed32",
                   "minimum": 30,
                   "exclusiveMaximum": 40,
@@ -1102,6 +1159,7 @@
                 },
                 "ne": {
                   "type": "number",
+                  "format": "double",
                   "x-primitive": "double",
                   "exclusiveMaximum": 30,
                   "minimum": 40,
@@ -1109,6 +1167,7 @@
                 },
                 "nf": {
                   "type": "number",
+                  "format": "double",
                   "x-primitive": "double",
                   "exclusiveMaximum": 30,
                   "minimum": 40,
@@ -1116,6 +1175,7 @@
                 },
                 "ng": {
                   "type": "integer",
+                  "format": "uint32",
                   "minimum": 0,
                   "maximum": 4294967295,
                   "x-primitive": "uint32",
@@ -1137,6 +1197,7 @@
                 },
                 "nh": {
                   "type": "number",
+                  "format": "float",
                   "x-primitive": "float",
                   "not": {
                     "oneOf": [
@@ -1154,6 +1215,7 @@
                 },
                 "ni": {
                   "type": "integer",
+                  "format": "uint32",
                   "minimum": 200,
                   "maximum": 4294967295,
                   "x-primitive": "uint32",
@@ -1438,18 +1500,21 @@
               "properties": {
                 "ba": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "const": "foo",
                   "description": "x must be set to \"foo\" (\"\\x66\\x6f\\x6f\")"
                 },
                 "bb": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "const": "f09028bc",
                   "description": "x must be set to \"\\xf0\\x90\\x28\\xbc\""
                 },
                 "bc": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 3,
                   "maxLength": 3,
@@ -1457,12 +1522,14 @@
                 },
                 "bd": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 3,
                   "description": "x must be at least 3 bytes long"
                 },
                 "be": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 5,
                   "maxLength": 10,
@@ -1470,30 +1537,35 @@
                 },
                 "bf": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": "^[00-7F]+$",
                   "description": "x must be a non-empty, ASCII byte sequence"
                 },
                 "bg": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": "^99.*",
                   "description": "x must begin with \"\\x99\""
                 },
                 "bh": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": ".*buz7a$",
                   "description": "x must end with \"buz\\x7a\""
                 },
                 "bi": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": ".*baz.*",
                   "description": "x must contain \"baz\" anywhere inside it"
                 },
                 "bj": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "oneOf": [
                     {
@@ -1513,6 +1585,7 @@
                 },
                 "bk": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "not": {
                     "oneOf": [
@@ -1530,6 +1603,7 @@
                 },
                 "bl": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "oneOf": [
                     {
@@ -1548,6 +1622,7 @@
                 },
                 "bm": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "anyOf": [
                     {
@@ -1563,14 +1638,14 @@
                 },
                 "bn": {
                   "type": "string",
-                  "x-primitive": "bytes",
                   "format": "ipv4",
+                  "x-primitive": "bytes",
                   "description": "x must be a valid IPv4 address in byte format\neg: \"\\xC0\\xA8\\x00\\x01\""
                 },
                 "bo": {
                   "type": "string",
-                  "x-primitive": "bytes",
                   "format": "ipv6",
+                  "x-primitive": "bytes",
                   "description": "x must be a valid IPv6 address in byte format\neg: \"\\x20\\x01\\x0D\\xB8\\x85\\xA3\\x00\\x00\\x00\\x00\\x8A\\x2E\\x03\\x70\\x73\\x34\""
                 }
               },
@@ -1601,6 +1676,7 @@
                   "type": "array",
                   "items": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32",
@@ -1623,6 +1699,7 @@
                     "properties": {
                       "id": {
                         "type": "integer",
+                        "format": "uint64",
                         "maximum": 9007199254740991,
                         "x-primitive": "uint64",
                         "exclusiveMinimum": 999
@@ -1648,12 +1725,14 @@
                         "properties": {
                           "lat": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -90,
                             "maximum": 90
                           },
                           "lng": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -180,
                             "maximum": 180
@@ -1673,6 +1752,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "description": "x must contain exactly 7 elements"
                   },
@@ -1684,6 +1764,7 @@
                   "type": "array",
                   "items": {
                     "type": "integer",
+                    "format": "int64",
                     "minimum": -9007199254740991,
                     "maximum": 9007199254740991,
                     "x-primitive": "int64",
@@ -1696,6 +1777,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "description": "x must contain positive float values",
                     "exclusiveMinimum": 0
@@ -1716,6 +1798,7 @@
                     "properties": {
                       "id": {
                         "type": "integer",
+                        "format": "uint64",
                         "maximum": 9007199254740991,
                         "x-primitive": "uint64",
                         "exclusiveMinimum": 999
@@ -1741,12 +1824,14 @@
                         "properties": {
                           "lat": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -90,
                             "maximum": 90
                           },
                           "lng": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -180,
                             "maximum": 180
@@ -1764,6 +1849,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "description": "x must contain positive float values",
                     "exclusiveMinimum": 0
@@ -1784,6 +1870,7 @@
                     "properties": {
                       "id": {
                         "type": "integer",
+                        "format": "uint64",
                         "maximum": 9007199254740991,
                         "x-primitive": "uint64",
                         "exclusiveMinimum": 999
@@ -1809,12 +1896,14 @@
                         "properties": {
                           "lat": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -90,
                             "maximum": 90
                           },
                           "lng": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -180,
                             "maximum": 180
@@ -1862,6 +1951,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1881,12 +1971,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1905,12 +1997,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1929,12 +2023,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1953,12 +2049,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1977,12 +2075,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -2001,12 +2101,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -2025,12 +2127,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -2049,12 +2153,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"

--- a/test/documents/protovalidate-simple.result.json
+++ b/test/documents/protovalidate-simple.result.json
@@ -39,12 +39,14 @@
                 "properties": {
                   "na": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "const": 1.23,
                     "description": "x must equal 1.23 exactly"
                   },
                   "nb": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "x-primitive": "int32",
                     "exclusiveMaximum": 10,
@@ -52,6 +54,7 @@
                   },
                   "nc": {
                     "type": "integer",
+                    "format": "uint64",
                     "minimum": 20,
                     "maximum": 9007199254740991,
                     "x-primitive": "uint64",
@@ -59,6 +62,7 @@
                   },
                   "nd": {
                     "type": "number",
+                    "format": "fixed32",
                     "x-primitive": "fixed32",
                     "minimum": 30,
                     "exclusiveMaximum": 40,
@@ -66,6 +70,7 @@
                   },
                   "ne": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "exclusiveMaximum": 30,
                     "minimum": 40,
@@ -73,6 +78,7 @@
                   },
                   "nf": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "exclusiveMaximum": 30,
                     "minimum": 40,
@@ -80,6 +86,7 @@
                   },
                   "ng": {
                     "type": "integer",
+                    "format": "uint32",
                     "minimum": 0,
                     "maximum": 4294967295,
                     "x-primitive": "uint32",
@@ -101,6 +108,7 @@
                   },
                   "nh": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "not": {
                       "oneOf": [
@@ -118,6 +126,7 @@
                   },
                   "ni": {
                     "type": "integer",
+                    "format": "uint32",
                     "minimum": 200,
                     "maximum": 4294967295,
                     "x-primitive": "uint32",
@@ -401,18 +410,21 @@
                 "properties": {
                   "ba": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "const": "foo",
                     "description": "x must be set to \"foo\" (\"\\x66\\x6f\\x6f\")"
                   },
                   "bb": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "const": "f09028bc",
                     "description": "x must be set to \"\\xf0\\x90\\x28\\xbc\""
                   },
                   "bc": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 3,
                     "maxLength": 3,
@@ -420,12 +432,14 @@
                   },
                   "bd": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 3,
                     "description": "x must be at least 3 bytes long"
                   },
                   "be": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "minLength": 5,
                     "maxLength": 10,
@@ -433,30 +447,35 @@
                   },
                   "bf": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": "^[00-7F]+$",
                     "description": "x must be a non-empty, ASCII byte sequence"
                   },
                   "bg": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": "^99.*",
                     "description": "x must begin with \"\\x99\""
                   },
                   "bh": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": ".*buz7a$",
                     "description": "x must end with \"buz\\x7a\""
                   },
                   "bi": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "pattern": ".*baz.*",
                     "description": "x must contain \"baz\" anywhere inside it"
                   },
                   "bj": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "oneOf": [
                       {
@@ -476,6 +495,7 @@
                   },
                   "bk": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "not": {
                       "oneOf": [
@@ -493,6 +513,7 @@
                   },
                   "bl": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "oneOf": [
                       {
@@ -511,6 +532,7 @@
                   },
                   "bm": {
                     "type": "string",
+                    "format": "bytes",
                     "x-primitive": "bytes",
                     "anyOf": [
                       {
@@ -526,14 +548,14 @@
                   },
                   "bn": {
                     "type": "string",
-                    "x-primitive": "bytes",
                     "format": "ipv4",
+                    "x-primitive": "bytes",
                     "description": "x must be a valid IPv4 address in byte format\neg: \"\\xC0\\xA8\\x00\\x01\""
                   },
                   "bo": {
                     "type": "string",
-                    "x-primitive": "bytes",
                     "format": "ipv6",
+                    "x-primitive": "bytes",
                     "description": "x must be a valid IPv6 address in byte format\neg: \"\\x20\\x01\\x0D\\xB8\\x85\\xA3\\x00\\x00\\x00\\x00\\x8A\\x2E\\x03\\x70\\x73\\x34\""
                   }
                 },
@@ -562,6 +584,7 @@
                     "type": "array",
                     "items": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32",
@@ -584,6 +607,7 @@
                       "properties": {
                         "id": {
                           "type": "integer",
+                          "format": "uint64",
                           "maximum": 9007199254740991,
                           "x-primitive": "uint64",
                           "exclusiveMinimum": 999
@@ -609,12 +633,14 @@
                           "properties": {
                             "lat": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -90,
                               "maximum": 90
                             },
                             "lng": {
                               "type": "number",
+                              "format": "double",
                               "x-primitive": "double",
                               "minimum": -180,
                               "maximum": 180
@@ -634,6 +660,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "double",
                       "x-primitive": "double",
                       "description": "x must contain exactly 7 elements"
                     },
@@ -645,6 +672,7 @@
                     "type": "array",
                     "items": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64",
@@ -657,6 +685,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "float",
                       "x-primitive": "float",
                       "description": "x must contain positive float values",
                       "exclusiveMinimum": 0
@@ -667,6 +696,7 @@
                     "type": "array",
                     "items": {
                       "type": "number",
+                      "format": "float",
                       "x-primitive": "float",
                       "description": "x must contain positive float values",
                       "exclusiveMinimum": 0
@@ -700,6 +730,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -719,12 +750,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -743,12 +776,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -767,12 +802,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -791,12 +828,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -815,12 +854,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -839,12 +880,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -863,12 +906,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -887,12 +932,14 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "minimum": -9007199254740991,
                         "maximum": 9007199254740991,
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "minimum": -2147483648,
                         "maximum": 2147483647,
                         "x-primitive": "int32"
@@ -945,12 +992,14 @@
               "properties": {
                 "na": {
                   "type": "number",
+                  "format": "float",
                   "x-primitive": "float",
                   "const": 1.23,
                   "description": "x must equal 1.23 exactly"
                 },
                 "nb": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "x-primitive": "int32",
                   "exclusiveMaximum": 10,
@@ -958,6 +1007,7 @@
                 },
                 "nc": {
                   "type": "integer",
+                  "format": "uint64",
                   "minimum": 20,
                   "maximum": 9007199254740991,
                   "x-primitive": "uint64",
@@ -965,6 +1015,7 @@
                 },
                 "nd": {
                   "type": "number",
+                  "format": "fixed32",
                   "x-primitive": "fixed32",
                   "minimum": 30,
                   "exclusiveMaximum": 40,
@@ -972,6 +1023,7 @@
                 },
                 "ne": {
                   "type": "number",
+                  "format": "double",
                   "x-primitive": "double",
                   "exclusiveMaximum": 30,
                   "minimum": 40,
@@ -979,6 +1031,7 @@
                 },
                 "nf": {
                   "type": "number",
+                  "format": "double",
                   "x-primitive": "double",
                   "exclusiveMaximum": 30,
                   "minimum": 40,
@@ -986,6 +1039,7 @@
                 },
                 "ng": {
                   "type": "integer",
+                  "format": "uint32",
                   "minimum": 0,
                   "maximum": 4294967295,
                   "x-primitive": "uint32",
@@ -1007,6 +1061,7 @@
                 },
                 "nh": {
                   "type": "number",
+                  "format": "float",
                   "x-primitive": "float",
                   "not": {
                     "oneOf": [
@@ -1024,6 +1079,7 @@
                 },
                 "ni": {
                   "type": "integer",
+                  "format": "uint32",
                   "minimum": 200,
                   "maximum": 4294967295,
                   "x-primitive": "uint32",
@@ -1307,18 +1363,21 @@
               "properties": {
                 "ba": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "const": "foo",
                   "description": "x must be set to \"foo\" (\"\\x66\\x6f\\x6f\")"
                 },
                 "bb": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "const": "f09028bc",
                   "description": "x must be set to \"\\xf0\\x90\\x28\\xbc\""
                 },
                 "bc": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 3,
                   "maxLength": 3,
@@ -1326,12 +1385,14 @@
                 },
                 "bd": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 3,
                   "description": "x must be at least 3 bytes long"
                 },
                 "be": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "minLength": 5,
                   "maxLength": 10,
@@ -1339,30 +1400,35 @@
                 },
                 "bf": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": "^[00-7F]+$",
                   "description": "x must be a non-empty, ASCII byte sequence"
                 },
                 "bg": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": "^99.*",
                   "description": "x must begin with \"\\x99\""
                 },
                 "bh": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": ".*buz7a$",
                   "description": "x must end with \"buz\\x7a\""
                 },
                 "bi": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "pattern": ".*baz.*",
                   "description": "x must contain \"baz\" anywhere inside it"
                 },
                 "bj": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "oneOf": [
                     {
@@ -1382,6 +1448,7 @@
                 },
                 "bk": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "not": {
                     "oneOf": [
@@ -1399,6 +1466,7 @@
                 },
                 "bl": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "oneOf": [
                     {
@@ -1417,6 +1485,7 @@
                 },
                 "bm": {
                   "type": "string",
+                  "format": "bytes",
                   "x-primitive": "bytes",
                   "anyOf": [
                     {
@@ -1432,14 +1501,14 @@
                 },
                 "bn": {
                   "type": "string",
-                  "x-primitive": "bytes",
                   "format": "ipv4",
+                  "x-primitive": "bytes",
                   "description": "x must be a valid IPv4 address in byte format\neg: \"\\xC0\\xA8\\x00\\x01\""
                 },
                 "bo": {
                   "type": "string",
-                  "x-primitive": "bytes",
                   "format": "ipv6",
+                  "x-primitive": "bytes",
                   "description": "x must be a valid IPv6 address in byte format\neg: \"\\x20\\x01\\x0D\\xB8\\x85\\xA3\\x00\\x00\\x00\\x00\\x8A\\x2E\\x03\\x70\\x73\\x34\""
                 }
               },
@@ -1468,6 +1537,7 @@
                   "type": "array",
                   "items": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32",
@@ -1490,6 +1560,7 @@
                     "properties": {
                       "id": {
                         "type": "integer",
+                        "format": "uint64",
                         "maximum": 9007199254740991,
                         "x-primitive": "uint64",
                         "exclusiveMinimum": 999
@@ -1515,12 +1586,14 @@
                         "properties": {
                           "lat": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -90,
                             "maximum": 90
                           },
                           "lng": {
                             "type": "number",
+                            "format": "double",
                             "x-primitive": "double",
                             "minimum": -180,
                             "maximum": 180
@@ -1540,6 +1613,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "double",
                     "x-primitive": "double",
                     "description": "x must contain exactly 7 elements"
                   },
@@ -1551,6 +1625,7 @@
                   "type": "array",
                   "items": {
                     "type": "integer",
+                    "format": "int64",
                     "minimum": -9007199254740991,
                     "maximum": 9007199254740991,
                     "x-primitive": "int64",
@@ -1563,6 +1638,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "description": "x must contain positive float values",
                     "exclusiveMinimum": 0
@@ -1573,6 +1649,7 @@
                   "type": "array",
                   "items": {
                     "type": "number",
+                    "format": "float",
                     "x-primitive": "float",
                     "description": "x must contain positive float values",
                     "exclusiveMinimum": 0
@@ -1606,6 +1683,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1625,12 +1703,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1649,12 +1729,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1673,12 +1755,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1697,12 +1781,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1721,12 +1807,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1745,12 +1833,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1769,12 +1859,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"
@@ -1793,12 +1885,14 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "minimum": -9007199254740991,
                       "maximum": 9007199254740991,
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "minimum": -2147483648,
                       "maximum": 2147483647,
                       "x-primitive": "int32"

--- a/test/documents/realworld.train_run.proto.result.json
+++ b/test/documents/realworld.train_run.proto.result.json
@@ -34,6 +34,7 @@
                 "properties": {
                   "id": {
                     "type": "integer",
+                    "format": "int32",
                     "x-primitive": "int32",
                     "description": "ObjectId"
                   },
@@ -52,6 +53,7 @@
                     "properties": {
                       "year": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 9999,
@@ -59,6 +61,7 @@
                       },
                       "month": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 12,
@@ -66,6 +69,7 @@
                       },
                       "day": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 31,
@@ -105,10 +109,12 @@
                         "properties": {
                           "seconds": {
                             "type": "integer",
+                            "format": "int64",
                             "x-primitive": "int64"
                           },
                           "nanos": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -124,10 +130,12 @@
                         "properties": {
                           "seconds": {
                             "type": "integer",
+                            "format": "int64",
                             "x-primitive": "int64"
                           },
                           "nanos": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -146,10 +154,12 @@
                     "properties": {
                       "seconds": {
                         "type": "integer",
+                        "format": "int64",
                         "x-primitive": "int64"
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -187,6 +197,7 @@
                         "properties": {
                           "value": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -202,6 +213,7 @@
                         "properties": {
                           "value": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -210,6 +222,7 @@
                       },
                       "reihenfolge": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       },
                       "umsystem": {
@@ -225,6 +238,7 @@
                         "properties": {
                           "value": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -259,6 +273,7 @@
                         "properties": {
                           "value": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -288,11 +303,13 @@
                   "properties": {
                     "id": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32",
                       "description": "ObjectId"
                     },
                     "nodeId": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32",
                       "minimum": 0,
                       "maximum": 1200,
@@ -316,6 +333,7 @@
                       "properties": {
                         "year": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 9999,
@@ -323,6 +341,7 @@
                         },
                         "month": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 12,
@@ -330,6 +349,7 @@
                         },
                         "day": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 31,
@@ -337,6 +357,7 @@
                         },
                         "hours": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 23,
@@ -344,6 +365,7 @@
                         },
                         "minutes": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 59,
@@ -351,6 +373,7 @@
                         },
                         "seconds": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 60,
@@ -358,6 +381,7 @@
                         },
                         "nanos": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 999999999,
@@ -375,11 +399,13 @@
                               "properties": {
                                 "seconds": {
                                   "type": "integer",
+                                  "format": "int64",
                                   "x-primitive": "int64",
                                   "x-parser-schema-id": "<anonymous-schema-47>"
                                 },
                                 "nanos": {
                                   "type": "integer",
+                                  "format": "int32",
                                   "x-primitive": "int32",
                                   "x-parser-schema-id": "<anonymous-schema-48>"
                                 }
@@ -433,6 +459,7 @@
                       "properties": {
                         "year": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 9999,
@@ -440,6 +467,7 @@
                         },
                         "month": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 12,
@@ -447,6 +475,7 @@
                         },
                         "day": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 31,
@@ -454,6 +483,7 @@
                         },
                         "hours": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 23,
@@ -461,6 +491,7 @@
                         },
                         "minutes": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 59,
@@ -468,6 +499,7 @@
                         },
                         "seconds": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 60,
@@ -475,6 +507,7 @@
                         },
                         "nanos": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "minimum": 0,
                           "maximum": 999999999,
@@ -492,11 +525,13 @@
                               "properties": {
                                 "seconds": {
                                   "type": "integer",
+                                  "format": "int64",
                                   "x-primitive": "int64",
                                   "x-parser-schema-id": "<anonymous-schema-62>"
                                 },
                                 "nanos": {
                                   "type": "integer",
+                                  "format": "int32",
                                   "x-primitive": "int32",
                                   "x-parser-schema-id": "<anonymous-schema-63>"
                                 }
@@ -548,11 +583,13 @@
                       "properties": {
                         "event_id_from": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "description": "ObjectId"
                         },
                         "event_id_to": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32",
                           "description": "ObjectId"
                         },
@@ -565,6 +602,7 @@
                           "properties": {
                             "value": {
                               "type": "integer",
+                              "format": "int32",
                               "x-primitive": "int32"
                             }
                           },
@@ -606,6 +644,7 @@
                       "properties": {
                         "value": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -653,6 +692,7 @@
                               "properties": {
                                 "value": {
                                   "type": "integer",
+                                  "format": "int32",
                                   "x-primitive": "int32",
                                   "x-parser-schema-id": "<anonymous-schema-80>"
                                 }
@@ -670,6 +710,7 @@
                               "properties": {
                                 "value": {
                                   "type": "integer",
+                                  "format": "uint32",
                                   "x-primitive": "uint32",
                                   "x-parser-schema-id": "<anonymous-schema-82>"
                                 }
@@ -687,6 +728,7 @@
                               "properties": {
                                 "value": {
                                   "type": "integer",
+                                  "format": "uint64",
                                   "x-primitive": "uint64",
                                   "x-parser-schema-id": "<anonymous-schema-84>"
                                 }
@@ -697,6 +739,7 @@
                             },
                             "min_duration": {
                               "type": "integer",
+                              "format": "int32",
                               "x-primitive": "int32",
                               "x-parser-schema-id": "<anonymous-schema-85>"
                             },
@@ -729,12 +772,14 @@
                           "properties": {
                             "event_id_from": {
                               "type": "integer",
+                              "format": "int32",
                               "x-primitive": "int32",
                               "description": "ObjectId",
                               "x-parser-schema-id": "<anonymous-schema-89>"
                             },
                             "event_id_to": {
                               "type": "integer",
+                              "format": "int32",
                               "x-primitive": "int32",
                               "description": "ObjectId",
                               "x-parser-schema-id": "<anonymous-schema-90>"
@@ -748,6 +793,7 @@
                               "properties": {
                                 "value": {
                                   "type": "integer",
+                                  "format": "int32",
                                   "x-primitive": "int32",
                                   "x-parser-schema-id": "<anonymous-schema-92>"
                                 }
@@ -758,6 +804,7 @@
                             },
                             "min_duration": {
                               "type": "integer",
+                              "format": "int32",
                               "x-primitive": "int32",
                               "x-parser-schema-id": "<anonymous-schema-93>"
                             },
@@ -824,6 +871,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -839,6 +887,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -847,6 +896,7 @@
                   },
                   "reihenfolge": {
                     "type": "integer",
+                    "format": "int32",
                     "x-primitive": "int32"
                   },
                   "umsystem": {
@@ -862,6 +912,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -896,6 +947,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -940,6 +992,7 @@
               "properties": {
                 "id": {
                   "type": "integer",
+                  "format": "int32",
                   "x-primitive": "int32",
                   "description": "ObjectId"
                 },
@@ -958,6 +1011,7 @@
                   "properties": {
                     "year": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32",
                       "minimum": 0,
                       "maximum": 9999,
@@ -965,6 +1019,7 @@
                     },
                     "month": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32",
                       "minimum": 0,
                       "maximum": 12,
@@ -972,6 +1027,7 @@
                     },
                     "day": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32",
                       "minimum": 0,
                       "maximum": 31,
@@ -1011,10 +1067,12 @@
                       "properties": {
                         "seconds": {
                           "type": "integer",
+                          "format": "int64",
                           "x-primitive": "int64"
                         },
                         "nanos": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1030,10 +1088,12 @@
                       "properties": {
                         "seconds": {
                           "type": "integer",
+                          "format": "int64",
                           "x-primitive": "int64"
                         },
                         "nanos": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1052,10 +1112,12 @@
                   "properties": {
                     "seconds": {
                       "type": "integer",
+                      "format": "int64",
                       "x-primitive": "int64"
                     },
                     "nanos": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     }
                   },
@@ -1093,6 +1155,7 @@
                       "properties": {
                         "value": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1108,6 +1171,7 @@
                       "properties": {
                         "value": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1116,6 +1180,7 @@
                     },
                     "reihenfolge": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     },
                     "umsystem": {
@@ -1131,6 +1196,7 @@
                       "properties": {
                         "value": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1165,6 +1231,7 @@
                       "properties": {
                         "value": {
                           "type": "integer",
+                          "format": "int32",
                           "x-primitive": "int32"
                         }
                       },
@@ -1194,11 +1261,13 @@
                 "properties": {
                   "id": {
                     "type": "integer",
+                    "format": "int32",
                     "x-primitive": "int32",
                     "description": "ObjectId"
                   },
                   "nodeId": {
                     "type": "integer",
+                    "format": "int32",
                     "x-primitive": "int32",
                     "minimum": 0,
                     "maximum": 1200,
@@ -1222,6 +1291,7 @@
                     "properties": {
                       "year": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 9999,
@@ -1229,6 +1299,7 @@
                       },
                       "month": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 12,
@@ -1236,6 +1307,7 @@
                       },
                       "day": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 31,
@@ -1243,6 +1315,7 @@
                       },
                       "hours": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 23,
@@ -1250,6 +1323,7 @@
                       },
                       "minutes": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 59,
@@ -1257,6 +1331,7 @@
                       },
                       "seconds": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 60,
@@ -1264,6 +1339,7 @@
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 999999999,
@@ -1281,11 +1357,13 @@
                             "properties": {
                               "seconds": {
                                 "type": "integer",
+                                "format": "int64",
                                 "x-primitive": "int64",
                                 "x-parser-schema-id": "<anonymous-schema-47>"
                               },
                               "nanos": {
                                 "type": "integer",
+                                "format": "int32",
                                 "x-primitive": "int32",
                                 "x-parser-schema-id": "<anonymous-schema-48>"
                               }
@@ -1339,6 +1417,7 @@
                     "properties": {
                       "year": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 9999,
@@ -1346,6 +1425,7 @@
                       },
                       "month": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 12,
@@ -1353,6 +1433,7 @@
                       },
                       "day": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 31,
@@ -1360,6 +1441,7 @@
                       },
                       "hours": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 23,
@@ -1367,6 +1449,7 @@
                       },
                       "minutes": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 59,
@@ -1374,6 +1457,7 @@
                       },
                       "seconds": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 60,
@@ -1381,6 +1465,7 @@
                       },
                       "nanos": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "minimum": 0,
                         "maximum": 999999999,
@@ -1398,11 +1483,13 @@
                             "properties": {
                               "seconds": {
                                 "type": "integer",
+                                "format": "int64",
                                 "x-primitive": "int64",
                                 "x-parser-schema-id": "<anonymous-schema-62>"
                               },
                               "nanos": {
                                 "type": "integer",
+                                "format": "int32",
                                 "x-primitive": "int32",
                                 "x-parser-schema-id": "<anonymous-schema-63>"
                               }
@@ -1454,11 +1541,13 @@
                     "properties": {
                       "event_id_from": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "description": "ObjectId"
                       },
                       "event_id_to": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32",
                         "description": "ObjectId"
                       },
@@ -1471,6 +1560,7 @@
                         "properties": {
                           "value": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32"
                           }
                         },
@@ -1512,6 +1602,7 @@
                     "properties": {
                       "value": {
                         "type": "integer",
+                        "format": "int32",
                         "x-primitive": "int32"
                       }
                     },
@@ -1559,6 +1650,7 @@
                             "properties": {
                               "value": {
                                 "type": "integer",
+                                "format": "int32",
                                 "x-primitive": "int32",
                                 "x-parser-schema-id": "<anonymous-schema-80>"
                               }
@@ -1576,6 +1668,7 @@
                             "properties": {
                               "value": {
                                 "type": "integer",
+                                "format": "uint32",
                                 "x-primitive": "uint32",
                                 "x-parser-schema-id": "<anonymous-schema-82>"
                               }
@@ -1593,6 +1686,7 @@
                             "properties": {
                               "value": {
                                 "type": "integer",
+                                "format": "uint64",
                                 "x-primitive": "uint64",
                                 "x-parser-schema-id": "<anonymous-schema-84>"
                               }
@@ -1603,6 +1697,7 @@
                           },
                           "min_duration": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32",
                             "x-parser-schema-id": "<anonymous-schema-85>"
                           },
@@ -1635,12 +1730,14 @@
                         "properties": {
                           "event_id_from": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32",
                             "description": "ObjectId",
                             "x-parser-schema-id": "<anonymous-schema-89>"
                           },
                           "event_id_to": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32",
                             "description": "ObjectId",
                             "x-parser-schema-id": "<anonymous-schema-90>"
@@ -1654,6 +1751,7 @@
                             "properties": {
                               "value": {
                                 "type": "integer",
+                                "format": "int32",
                                 "x-primitive": "int32",
                                 "x-parser-schema-id": "<anonymous-schema-92>"
                               }
@@ -1664,6 +1762,7 @@
                           },
                           "min_duration": {
                             "type": "integer",
+                            "format": "int32",
                             "x-primitive": "int32",
                             "x-parser-schema-id": "<anonymous-schema-93>"
                           },
@@ -1730,6 +1829,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     }
                   },
@@ -1745,6 +1845,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     }
                   },
@@ -1753,6 +1854,7 @@
                 },
                 "reihenfolge": {
                   "type": "integer",
+                  "format": "int32",
                   "x-primitive": "int32"
                 },
                 "umsystem": {
@@ -1768,6 +1870,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     }
                   },
@@ -1802,6 +1905,7 @@
                   "properties": {
                     "value": {
                       "type": "integer",
+                      "format": "int32",
                       "x-primitive": "int32"
                     }
                   },

--- a/test/documents/restrictions.proto.result.json
+++ b/test/documents/restrictions.proto.result.json
@@ -1,0 +1,129 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Example using ProtoBuff value restrictions",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "mychannel": {
+      "publish": {
+        "message": {
+          "schemaFormat": "application/vnd.google.protobuf;version=3",
+          "payload": {
+            "title": "RestrictedEntity",
+            "type": "object",
+            "required": [
+              "code",
+              "quantity",
+              "ratio",
+              "tags"
+            ],
+            "properties": {
+              "code": {
+                "type": "string",
+                "x-primitive": "string",
+                "pattern": "^[A-Z]{2}\\d+$",
+                "maxLength": 10,
+                "minLength": 3,
+                "description": "Identifier code."
+              },
+              "quantity": {
+                "type": "integer",
+                "format": "int32",
+                "minimum": 1,
+                "maximum": 100,
+                "x-primitive": "int32",
+                "multipleOf": 5,
+                "description": "Quantity of items."
+              },
+              "ratio": {
+                "type": "number",
+                "format": "double",
+                "x-primitive": "double",
+                "exclusiveMinimum": 0,
+                "exclusiveMaximum": 1,
+                "description": "Ratio strictly between 0 and 1."
+              },
+              "tags": {
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "x-primitive": "string",
+                  "description": "Tags."
+                },
+                "description": "Tags.",
+                "minItems": 1,
+                "maxItems": 5
+              },
+              "note": {
+                "type": "string",
+                "x-primitive": "string",
+                "description": "Optional free-text note (not required)."
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "testMessage": {
+        "schemaFormat": "application/vnd.google.protobuf;version=3",
+        "payload": {
+          "title": "RestrictedEntity",
+          "type": "object",
+          "required": [
+            "code",
+            "quantity",
+            "ratio",
+            "tags"
+          ],
+          "properties": {
+            "code": {
+              "type": "string",
+              "x-primitive": "string",
+              "pattern": "^[A-Z]{2}\\d+$",
+              "maxLength": 10,
+              "minLength": 3,
+              "description": "Identifier code."
+            },
+            "quantity": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 1,
+              "maximum": 100,
+              "x-primitive": "int32",
+              "multipleOf": 5,
+              "description": "Quantity of items."
+            },
+            "ratio": {
+              "type": "number",
+              "format": "double",
+              "x-primitive": "double",
+              "exclusiveMinimum": 0,
+              "exclusiveMaximum": 1,
+              "description": "Ratio strictly between 0 and 1."
+            },
+            "tags": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "x-primitive": "string",
+                "description": "Tags."
+              },
+              "description": "Tags.",
+              "minItems": 1,
+              "maxItems": 5
+            },
+            "note": {
+              "type": "string",
+              "x-primitive": "string",
+              "description": "Optional free-text note (not required)."
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/test/documents/restrictions.proto.yaml
+++ b/test/documents/restrictions.proto.yaml
@@ -1,0 +1,52 @@
+asyncapi: 2.0.0
+info:
+  title: Example using ProtoBuff value restrictions
+  version: '1.0.0'
+channels:
+  mychannel:
+    publish:
+      message:
+        $ref: '#/components/messages/testMessage'
+
+components:
+  messages:
+    testMessage:
+      schemaFormat: 'application/vnd.google.protobuf;version=3'
+      payload: |
+        syntax = "proto3";
+
+        message RestrictedEntity {
+            /*
+             * Identifier code.
+             * @Required
+             * @Pattern ^[A-Z]{2}\d+$
+             * @MinLength 3
+             * @MaxLength 10
+             */
+            optional string code = 1;
+
+            /*
+             * Quantity of items.
+             * @Minimum 1
+             * @Maximum 100
+             * @MultipleOf 5
+             */
+            int32 quantity = 2;
+
+            /*
+             * Ratio strictly between 0 and 1.
+             * @ExclusiveMinimum 0
+             * @ExclusiveMaximum 1
+             */
+            double ratio = 3;
+
+            /*
+             * Tags.
+             * @MinItems 1
+             * @MaxItems 5
+             */
+            repeated string tags = 4;
+
+            // Optional free-text note (not required).
+            optional string note = 5;
+        }

--- a/test/documents/simple.proto2.result.json
+++ b/test/documents/simple.proto2.result.json
@@ -27,12 +27,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -54,12 +56,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -103,12 +107,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
@@ -130,12 +136,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"

--- a/test/documents/simple.proto3.result.json
+++ b/test/documents/simple.proto3.result.json
@@ -27,12 +27,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -54,12 +56,14 @@
                 "properties": {
                   "x": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
                   },
                   "y": {
                     "type": "integer",
+                    "format": "int32",
                     "minimum": -2147483648,
                     "maximum": 2147483647,
                     "x-primitive": "int32"
@@ -103,12 +107,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
@@ -130,12 +136,14 @@
               "properties": {
                 "x": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"
                 },
                 "y": {
                   "type": "integer",
+                  "format": "int32",
                   "minimum": -2147483648,
                   "maximum": 2147483647,
                   "x-primitive": "int32"

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -141,6 +141,20 @@ describe('parse()', function () {
     );
   });
 
+  it('should parse value restriction and required annotations', async function () {
+    const document = await parseSpec('./documents/restrictions.proto.yaml');
+
+    if (UPDATE_RESULTS) {
+      writeResults(document, './documents/restrictions.proto.result.json');
+    }
+
+    expect(
+      stripParserExtraInfos(document?.json())
+    ).toEqual(
+      readResultFile('./documents/restrictions.proto.result.json')
+    );
+  });
+
   it('multiple root messages in proto schema should fail', async function () {
     const {document, diagnostics} = await coreParser.parse(
       fs.readFileSync(path.resolve(__dirname, './documents/invalid.multiple_root.yaml'), 'utf8')


### PR DESCRIPTION
…ions

- add JSON schema `format` for all protobuf scalar types (e.g. int64 -> {"type":"integer","format":"int64"}, bytes -> "byte"); numeric min/max limits are kept unchanged
- add `@Required` field annotation; a field is required if it is proto2 `required`, a non-optional proto3 field, or annotated with `@Required` (additive, backward compatible)
- fix comment-annotation matchers that used double-escaped regex literals and therefore never matched: @Pattern, @Minimum, @Maximum, @ExclusiveMinimum, @ExclusiveMaximum, @MultipleOf, plus @MaxLength and @MinLength which were copy-paste bound to @MultipleOf
- @MinItems/@MaxItems now apply to the array property instead of the parent message object
- strip @Required and @Pattern values from generated descriptions
- add restrictions.proto fixture and regenerate golden result files