### PR TITLE
docs: overhaul README and add contributor/agent guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,191 @@
+# AGENTS.md
+
+Guidance for human contributors and AI coding agents working in this repository. This project is
+`@asyncapi/protobuf-schema-parser`: an [`@asyncapi/parser`](https://github.com/asyncapi/parser-js)
+schema-parser plugin that converts Protocol Buffers (`.proto`) message definitions into AsyncAPI
+(JSON Schema based) schemas.
+
+Keep changes focused, factual and consistent with the conventions below. When behaviour changes,
+update or add a fixture (see section 6) so the mapping stays covered by tests.
+
+## 1. Technology Stack
+
+- **Language:** TypeScript (compiled with `tsc`, `strict` mode on).
+- **Runtime:** Node.js `>= 18`. The library is also browser-compatible (`sideEffects: false`), so
+  avoid Node-only APIs in `src/` outside of test code.
+- **Core dependencies:**
+  - `@asyncapi/parser` — the host parser this plugin registers with; source of the `SchemaParser`
+    type and the schema types under `@asyncapi/parser/esm/...`.
+  - `protobufjs` — parses the raw `.proto` string into a reflection tree.
+  - `@types/protocol-buffers-schema` — type definitions.
+- **Build output:** dual module builds — ES modules in `esm/` (`build:esm`) and CommonJS in `cjs/`
+  (`build:cjs`). `package.json` points `main` at `cjs/`, `module` at `esm/`, and `types` at
+  `esm/index.d.ts`.
+- **Tooling:** Jest (`@swc/jest`) for tests, ESLint for linting, `semantic-release` for releases,
+  `markdown-toc` for the README table of contents.
+
+## 2. Project Structure
+
+```
+src/
+  index.ts                 Parser factory + @asyncapi/parser schema-parser contract
+  protoj2jsonSchema.ts     Core converter (Proto2JsonSchema class)
+  primitive-types.ts       Scalar Protobuf -> JSON Schema type/format map
+  google-types.ts          Bundled google/type/*.proto definitions
+  pathUtils.ts             Import path resolution helpers
+  protoc-gen-validate.ts   (validate.rules) option mapping
+  protovalidate.ts         (buf.validate.field) option mapping + shared validator logic
+test/
+  parser.spec.ts           Test suite
+  documents/*.yaml         AsyncAPI input fixtures
+  documents/*.result.json  Expected parsed output for each fixture
+esm/  cjs/                 Generated build output (do not edit by hand; git-ignored)
+```
+
+Edit only `src/` and `test/`. Never hand-edit `esm/` or `cjs/` — they are produced by the build and
+are git-ignored.
+
+## 3. Coding Standards & Conventions
+
+- Follow `.editorconfig` and `.eslintrc`: 2-space indentation, single quotes, semicolons required,
+  LF line endings, final newline, `no-var`, `prefer-const`, `object-shorthand`, `prefer-template`.
+- Run `npm run lint` (or `npm run lint:fix`) before proposing changes. Lint must pass with
+  `--max-warnings 0`.
+- Prefer small, private helper methods on the converter class over deeply nested logic. The
+  `sonarjs/cognitive-complexity` rule is a warning; where a function is unavoidably complex, the
+  codebase disables it with a scoped `eslint-disable` comment rather than leaving warnings.
+- Preserve the existing use of non-standard `x-` keywords (see section 5) — they are part of the
+  output contract that downstream tooling relies on.
+- Keep the library free of Node-only or filesystem APIs (browser compatibility). File reads belong in
+  tests only.
+- Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) — releases are
+  driven by the commit prefix (`fix:`, `feat:`, `docs:`, `chore:`, `test:`, `refactor:`; add `!` for
+  breaking changes).
+
+## 4. The schema-parser contract
+
+`src/index.ts` exports `ProtoBuffSchemaParser()` (both a named and the default export). It returns an
+object implementing the `SchemaParser` interface from `@asyncapi/parser`:
+
+- **`getMimeTypes()`** — returns the schema formats this parser handles:
+  `application/vnd.google.protobuf;version=2` and `application/vnd.google.protobuf;version=3`.
+  `@asyncapi/parser` routes any message payload whose `schemaFormat` matches one of these strings to
+  this parser.
+- **`parse(input)`** — receives `input.data` (the raw Protobuf string) and returns the converted
+  AsyncAPI schema. Delegates to `proto2jsonSchema(input.data)`.
+- **`validate(input)`** — returns `Promise<SchemaValidateResult[]>`. An empty array means valid; any
+  parse error is caught and returned as a single result with `message` and `input.path` (the
+  Protobuf parser does not provide an error path).
+
+A consumer registers the parser with `parser.registerSchemaParser(ProtoBuffSchemaParser())`. Keep
+this three-method surface stable; changing method names or the MIME-type strings is a breaking
+change.
+
+## 5. Protobuf -> AsyncAPI mapping rules
+
+The converter (`src/protoj2jsonSchema.ts`, class `Proto2JsonSchema`) parses the schema with
+`protobufjs` (options `keepCase: true`, `alternateCommentMode: true`), resolves the root message, and
+walks the tree. Core rules:
+
+- **Message** -> `{ title, type: 'object', properties, required }`. The `required` array is dropped
+  when empty. The message comment becomes `description`.
+- **Root selection** -> the message not used as a field type by any other message is the root. If
+  more than one candidate remains, one must be annotated `@RootNode`, else throw `Found more than one
+  root proto messages`. Zero candidates throws `Not found a root proto messages`.
+- **Scalar field** -> looked up in `PrimitiveTypes.PRIMITIVE_TYPES_WITH_LIMITS` (or
+  `PRIMITIVE_TYPES_MINIMAL` when `primitiveTypesWithLimits` is `false`); sets `type`, `format`,
+  `x-primitive`, and numeric `minimum`/`maximum` where defined.
+- **Message-typed field** -> the referenced message compiled inline, plus `x-type` = Protobuf type
+  name.
+- **Enum** -> `{ title, type: 'string', enum: [names], 'x-enum-mapping': { name: number } }`; a field
+  referencing an enum also gets `x-type`.
+- **`repeated` field** -> `{ type: 'array', items: <field schema> }`. Supports `@MinItems`/`@MaxItems`
+  and validator-framework `min_items`/`max_items`/`unique`/`items`.
+- **`oneof` with 2+ members** -> a property named after the `oneof` holding `{ oneOf: [...] }`; each
+  variant carries `x-oneof-item` = originating field name. Single-member synthetic `oneof`s (proto3
+  `optional`, names starting with `_`) are filtered out.
+- **Required membership** is additive: proto2 `required`, non-optional proto3 field, or `@Required`.
+- **Recursion guard**: if a message type appears twice on the current stack branch, stop descending.
+- **Comments** become `description` after `@`-annotations are stripped. Field annotations
+  (`@Min`/`@Max`/`@Pattern`/`@ExclusiveMinimum`/`@ExclusiveMaximum`/`@MultipleOf`/`@MinLength`/
+  `@MaxLength`/`@MinItems`/`@MaxItems`/`@Default`/`@Example`/`@Required`) map to the corresponding
+  JSON Schema keywords.
+- **Head `@Option`** annotations configure the converter (currently only
+  `primitiveTypesWithLimits`).
+- **Validation frameworks**: `(validate.rules)` (protoc-gen-validate, `src/protoc-gen-validate.ts`)
+  and `(buf.validate.field)` (protovalidate, `src/protovalidate.ts`) are translated to JSON Schema
+  validators (`const`, `lt`/`lte`/`gt`/`gte` -> exclusive/inclusive `minimum`/`maximum`,
+  `in`/`not_in` -> `oneOf`/`not`, string length/pattern/format rules, `ignore_empty` -> optional).
+
+**Imports/refs** are unsupported except the bundled well-known definitions (`google/protobuf/*` via
+`protobufjs`, `google/type/*` via `google-types.ts`, and the two validation `.proto` files). Any
+other `import` throws.
+
+The `x-` keywords (`x-primitive`, `x-type`, `x-enum-mapping`, `x-oneof-item`) are an intentional part
+of the output. Do not remove or rename them without treating it as a breaking change.
+
+## 6. Testing
+
+- Tests live in `test/parser.spec.ts` and run via `npm test` (`jest --coverage`).
+- Each case parses an AsyncAPI YAML fixture from `test/documents/*.yaml` through a real
+  `@asyncapi/parser` `Parser` with `ProtoBuffSchemaParser` registered, then deep-equals the result
+  against the matching `*.result.json` (with `x-parser-*` internals stripped).
+- When you change the mapping, add or update a fixture pair (`<name>.yaml` + `<name>.result.json`). To
+  regenerate expected outputs, temporarily set `UPDATE_RESULTS = true` in `parser.spec.ts`, run the
+  suite, review the diff, then set it back to `false`. Never commit with `UPDATE_RESULTS = true`.
+- Invalid-input fixtures (e.g. `invalid.multiple_root.yaml`, `invalid.schema-empty.yaml`) assert that
+  parsing fails and produces diagnostics. Add negative cases for new error conditions.
+- Cover both proto2 and proto3 where relevant, and keep the `google` well-known-type and validation
+  fixtures green when touching import handling or the validator mappers.
+
+## 7. Project-specific patterns & invariants
+
+- A converted payload always has exactly one root object (JSON Schema has a single root). Multiple
+  unparented messages require `@RootNode` disambiguation.
+- The converter runs synchronously; `parse` returns the schema value directly (the `SchemaParser`
+  interface also permits a Promise).
+- `protobufjs` is parsed with `keepCase: true` — field/enum names are preserved verbatim; do not
+  camel-case them.
+- The scalar map is the single source of truth for scalar output. Derive the "minimal" (no
+  `minimum`/`maximum`) variant from the "with limits" map rather than duplicating entries.
+- Error messages are user-facing (surfaced through `validate` diagnostics) — keep them clear and
+  specific.
+- Keep `README.md` in sync with mapping/annotation/option changes, and regenerate its table of
+  contents with `npm run generate:readme:toc` when headings change.
+
+## 8. Example
+
+Input (Protobuf embedded in an AsyncAPI message payload):
+
+```proto
+message Point {
+  int32 x = 1;
+  int32 y = 2;
+  optional string label = 3;
+}
+```
+
+Output (converted AsyncAPI schema, abbreviated):
+
+```json
+{
+  "title": "Point",
+  "type": "object",
+  "required": ["x", "y"],
+  "properties": {
+    "x": { "type": "integer", "format": "int32", "minimum": -2147483648, "maximum": 2147483647, "x-primitive": "int32" },
+    "y": { "type": "integer", "format": "int32", "minimum": -2147483648, "maximum": 2147483647, "x-primitive": "int32" },
+    "label": { "type": "string", "x-primitive": "string" }
+  }
+}
+```
+
+## Related projects
+
+Public AsyncAPI and Protobuf ecosystem projects only:
+
+- [`@asyncapi/parser`](https://github.com/asyncapi/parser-js) — the host parser this plugin extends.
+- [Protocol Buffers](https://protobuf.dev/) — the input schema language.
+- [`protobufjs`](https://github.com/protobufjs/protobuf.js) — the underlying `.proto` parser.
+- [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate) and
+  [protovalidate](https://github.com/bufbuild/protovalidate) — supported validation frameworks.

--- a/README.md
+++ b/README.md
@@ -1,31 +1,80 @@
 # ProtoBuff Data Types Schema Parser
 
-A schema parser for Protocol Buffers data types.
-For ProtoBuff 2 and 3 schemas.
+[![npm version](https://img.shields.io/npm/v/@asyncapi/protobuf-schema-parser.svg)](https://www.npmjs.com/package/@asyncapi/protobuf-schema-parser)
+[![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](./LICENSE)
+[![Node](https://img.shields.io/badge/node-%3E%3D18-brightgreen.svg)](https://nodejs.org)
 
-There is no explicit distinction between ProtoBuff 2 and 3. You dont have to expect any errors if your `schemaFormat`
-is `application/vnd.google.protobuf;version=2` defined, but your schema is proto3.
+A schema parser for [Protocol Buffers](https://protobuf.dev/) data types. It plugs into
+[`@asyncapi/parser`](https://github.com/asyncapi/parser-js) and lets you embed `.proto` message
+definitions directly in the `payload` (or `schema`) of an AsyncAPI document. During parsing, the
+Protobuf definition is converted into an AsyncAPI (JSON Schema based) schema so the rest of the
+AsyncAPI tooling can work with it like any other message payload.
 
-Version >= `2.0.0` of package is only supported by `@asyncapi/parser` version >= `2.0.0`.
+## Overview
 
-This package is browser-compatible.
+AsyncAPI messages can carry payloads described in different schema languages. `@asyncapi/parser`
+delegates any payload whose `schemaFormat` it does not understand natively to a registered
+_schema parser_. This package is the schema parser for Protocol Buffers: you register it once, and
+every message payload tagged with a Protobuf `schemaFormat` is parsed and expanded in place into an
+equivalent AsyncAPI schema.
+
+- Works with **Protobuf 2 and Protobuf 3** schemas.
+- Registers for the schema formats
+  `application/vnd.google.protobuf;version=2` and `application/vnd.google.protobuf;version=3`.
+- Maps Protobuf messages, scalars, enums, `repeated` fields, `oneof` and nested types to JSON Schema.
+- Understands leading comments as descriptions and a set of `@`-annotations for validation, defaults
+  and examples.
+- Optionally maps [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate) and
+  [protovalidate](https://github.com/bufbuild/protovalidate) rules to JSON Schema validators.
+- Browser-compatible and ships both CommonJS and ES module builds.
+
+> There is no strict distinction between Protobuf 2 and 3. Declaring `schemaFormat` as
+> `application/vnd.google.protobuf;version=2` while providing a proto3 schema (or vice versa) does
+> not by itself cause an error.
+>
+> Version `>= 2.0.0` of this package requires `@asyncapi/parser` `>= 2.0.0`; the `3.x` line targets
+> `@asyncapi/parser` `>= 3.6.0`.
+
+<!-- toc -->
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [Supported input](#supported-input)
+- [How it works](#how-it-works)
+- [Scalar type formats](#scalar-type-formats)
+- [Comments and annotations](#comments-and-annotations)
+  * [Per field annotation](#per-field-annotation)
+  * [Per message annotation](#per-message-annotation)
+  * [Head annotation](#head-annotation)
+  * [Head annotation "Option"](#head-annotation-option)
+- [Supported validation frameworks](#supported-validation-frameworks)
+- [Development](#development)
+- [Contributing](#contributing)
+- [License](#license)
+
+<!-- tocstop -->
 
 ## Installation
 
-```
+```sh
 npm install @asyncapi/protobuf-schema-parser
-// OR
+# or
 yarn add @asyncapi/protobuf-schema-parser
 ```
 
+`@asyncapi/parser` is required to use this package. Requires Node.js `>= 18`.
+
 ## Usage
 
+Create a `Parser`, register the Protobuf schema parser on it, then parse an AsyncAPI document that
+uses a Protobuf `schemaFormat`. The Protobuf source goes into the message `payload` as a string.
+
 ```ts
-import {Parser} from '@asyncapi/parser';
-import {ProtoSchemaParser} from '@asyncapi/protobuf-schema-parser'
+import { Parser } from '@asyncapi/parser';
+import { ProtoBuffSchemaParser } from '@asyncapi/protobuf-schema-parser';
 
 const parser = new Parser();
-parser.registerSchemaParser(ProtoSchemaParser());
+parser.registerSchemaParser(ProtoBuffSchemaParser());
 
 const asyncapiWithProto = `
 asyncapi: 2.0.0
@@ -38,94 +87,122 @@ channels:
       message:
         schemaFormat: 'application/vnd.google.protobuf;version=3'
         payload: |
-            message Point {
-                required int32 x = 1;
-                required int32 y = 2;
-                optional string label = 3;
-            }
+          message Point {
+            required int32 x = 1;
+            required int32 y = 2;
+            optional string label = 3;
+          }
 
-            message Line {
-                required Point start = 1;
-                required Point end = 2;
-                optional string label = 3;
-            }
-`
+          message Line {
+            required Point start = 1;
+            required Point end = 2;
+            optional string label = 3;
+          }
+`;
 
-const {document} = await parser.parse(asyncapiWithProto);
+const { document, diagnostics } = await parser.parse(asyncapiWithProto);
 ```
+
+The same works with CommonJS:
 
 ```js
-const {Parser} = require('@asyncapi/parser');
-const {ProtoSchemaParser} = require('@asyncapi/protobuf-schema-parser');
+const { Parser } = require('@asyncapi/parser');
+const { ProtoBuffSchemaParser } = require('@asyncapi/protobuf-schema-parser');
 
 const parser = new Parser();
-parser.registerSchemaParser(ProtoSchemaParser());
-
-const asyncapiWithProto = `
-asyncapi: 2.0.0
-info:
-  title: Example with ProtoBuff
-  version: 0.1.0
-channels:
-  example:
-    publish:
-      message:
-        schemaFormat: 'application/vnd.google.protobuf;version=3'
-        payload: |
-            message Point {
-                required int32 x = 1;
-                required int32 y = 2;
-                optional string label = 3;
-            }
-
-            message Line {
-                required Point start = 1;
-                required Point end = 2;
-                optional string label = 3;
-            }
-`
-
-const {document} = await parser.parse(asyncapiWithProto);
+parser.registerSchemaParser(ProtoBuffSchemaParser());
 ```
 
-Place your protoBuff schema as string in `payload` to get it parsed.
+Notes:
 
-References are NOT supported:
+- `ProtoBuffSchemaParser` is exported both as a named export and as the default export. Call it to
+  obtain the parser instance, then pass that instance to `registerSchemaParser`.
+- Place your Protobuf schema as a string in the message `payload` (AsyncAPI 2.x) or in the schema
+  object's `schema` keyword (AsyncAPI 3.x) to get it parsed. See the fixtures under
+  [`test/documents`](./test/documents) for both variants.
+- After parsing, the message payload in `document` is the converted AsyncAPI schema.
 
-- no support for `$ref`
-- no support for [`import`](https://protobuf.dev/programming-guides/proto3/#importing-definitions), except the default
-  google types:
-    - google/protobuf/*
-    - google/type/*
+## Supported input
+
+- **Protobuf 2 and Protobuf 3** message definitions.
+- The two registered schema formats:
+  - `application/vnd.google.protobuf;version=2`
+  - `application/vnd.google.protobuf;version=3`
+
+References are **not** supported:
+
+- No support for `$ref` inside the Protobuf payload.
+- No support for [`import`](https://protobuf.dev/programming-guides/proto3/#importing-definitions),
+  with the exception of the bundled well-known definitions:
+  - `google/protobuf/*` (provided by `protobufjs`)
+  - `google/type/*` (bundled with this package)
+  - the validation definitions `validate/validate.proto` and `buf/validate/validate.proto`
+
+Any other `import` throws an error during parsing.
+
+## How it works
+
+Each AsyncAPI document may contain several message payloads. For every payload whose `schemaFormat`
+matches one of the registered MIME types, the parser hands the raw Protobuf string to the converter,
+which uses [`protobufjs`](https://github.com/protobufjs/protobuf.js) to parse it and then walks the
+message tree, emitting a JSON Schema based AsyncAPI schema.
+
+Because a JSON Schema has a single root, the converter first determines the **root message**: the
+message that is not referenced as a field type by any other message. If several candidates remain,
+annotate the intended root with `@RootNode`; otherwise parsing fails with `Found more than one root
+proto messages`. If no root can be found, parsing fails with `Not found a root proto messages`.
+
+The main mapping rules:
+
+| Protobuf construct | AsyncAPI / JSON Schema output |
+|--------------------|-------------------------------|
+| `message` | `{ "title": <name>, "type": "object", "properties": { ... } }`, plus a `required` list |
+| Scalar field (e.g. `int32`, `string`) | `type` + `format` from the [scalar type map](#scalar-type-formats), plus `x-primitive` (and `minimum`/`maximum` for numeric types) |
+| Message-typed field | The referenced message compiled inline, plus `x-type` set to the Protobuf type name |
+| `enum` | `{ "type": "string", "enum": [<names>], "x-enum-mapping": { <name>: <number> } }` |
+| `repeated` field | `{ "type": "array", "items": <field schema> }` |
+| `oneof` with 2+ members | A property named after the `oneof` holding `{ "oneOf": [ ... ] }`; each variant carries `x-oneof-item` with the field name |
+| Field / message comment | `description` (with `@`-annotations stripped out) |
+
+Field membership in the `required` list is additive: a field is marked required if it is proto2
+`required`, a non-optional proto3 field, or annotated with `@Required`.
+
+Recursive messages are supported: when the same message type is encountered twice on the current
+branch, the converter stops descending to avoid an infinite loop.
+
+Non-standard (`x-`) keywords are used to preserve Protobuf information that has no direct JSON Schema
+equivalent: `x-primitive` (original scalar type), `x-type` (referenced message/enum name),
+`x-enum-mapping` (enum name to numeric value), and `x-oneof-item` (the `oneof` field a variant came
+from).
 
 ## Scalar type formats
 
-Each protobuf scalar type is mapped to a JSON schema `type` plus a `format` that preserves the
-original protobuf wire type. For example `int64` becomes `{"type": "integer", "format": "int64"}`
-and `bytes` becomes `{"type": "string", "format": "bytes"}`. The protobuf type is additionally kept
+Each Protobuf scalar type is mapped to a JSON Schema `type` plus a `format` that preserves the
+original Protobuf wire type. For example `int64` becomes `{"type": "integer", "format": "int64"}`
+and `bytes` becomes `{"type": "string", "format": "bytes"}`. The Protobuf type is additionally kept
 in the non-standard `x-primitive` keyword. By default numeric types also carry `minimum`/`maximum`
 limits (see the `primitiveTypesWithLimits` option).
 
-## Comments
+## Comments and annotations
 
-Each field of a message may have a comment witch will be reflected as json schema `description`.
+Each field of a message may have a comment which is reflected as the JSON Schema `description`.
 Furthermore, the comment can contain the following annotations:
 
-```
+```proto
 message Point {
     /*
-     * The cordinate on the x axis.
+     * The coordinate on the x axis.
      * @Default 99
      * @Min 0
-     * @Max 100 
+     * @Max 100
      */
     required int32 x = 1;
-    
+
     /*
-     * The cordinate on the y axis.
+     * The coordinate on the y axis.
      * @Default 12
      * @Min 0
-     * @Max 100 
+     * @Max 100
      */
     required int32 y = 2;
     optional string label = 3;
@@ -134,40 +211,39 @@ message Point {
 
 ### Per field annotation
 
-| annotation         	 | description 	                                                                                                                        |
-|----------------------|:-------------------------------------------------------------------------------------------------------------------------------------|
-| @Example  	          | json schema examples keyword. Can exists multiple times. If used with an complex type, an single lines json object hast to be used.	 |
-| @Min or @Minimum     | json schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range)	                          |
-| @Max or @Maximum     | json schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range)                           |
-| @Pattern             | json scheme [string validator](https://json-schema.org/understanding-json-schema/reference/string#regexp)	                           |
-| @ExclusiveMinimum    | json schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range)                           |
-| @ExclusiveMaximum    | json schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range)	                          |
-| @MultipleOf          | json schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#multiples)   	                   |
-| @MinLength           | json scheme [string validator](https://json-schema.org/understanding-json-schema/reference/string#length)                            |
-| @MaxLength           | json scheme [string validator](https://json-schema.org/understanding-json-schema/reference/string#length)                            |
-| @MinItems            | json scheme [array validator](https://json-schema.org/understanding-json-schema/reference/array#length)	                             |
-| @MaxItems            | json scheme [array validator](https://json-schema.org/understanding-json-schema/reference/array#length)		                            |
-| @Default             | json schema [default value](https://opis.io/json-schema/1.x/default-value.html)	                                                     |
-| @Required            | adds the field to the json schema `required` list. Additive: a field is required if it is proto2 `required`, a non-optional proto3 field, or annotated with `@Required` |
+| annotation | description |
+|------------|:------------|
+| @Example | JSON Schema `examples` keyword. Can appear multiple times. If used with a complex type, a single-line JSON object has to be used. |
+| @Min or @Minimum | JSON Schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range) |
+| @Max or @Maximum | JSON Schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range) |
+| @Pattern | JSON Schema [string validator](https://json-schema.org/understanding-json-schema/reference/string#regexp) |
+| @ExclusiveMinimum | JSON Schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range) |
+| @ExclusiveMaximum | JSON Schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#range) |
+| @MultipleOf | JSON Schema [numeric validator](https://json-schema.org/understanding-json-schema/reference/numeric#multiples) |
+| @MinLength | JSON Schema [string validator](https://json-schema.org/understanding-json-schema/reference/string#length) |
+| @MaxLength | JSON Schema [string validator](https://json-schema.org/understanding-json-schema/reference/string#length) |
+| @MinItems | JSON Schema [array validator](https://json-schema.org/understanding-json-schema/reference/array#length) |
+| @MaxItems | JSON Schema [array validator](https://json-schema.org/understanding-json-schema/reference/array#length) |
+| @Default | JSON Schema [default value](https://json-schema.org/understanding-json-schema/reference/annotations) |
+| @Required | Adds the field to the JSON Schema `required` list. Additive: a field is required if it is proto2 `required`, a non-optional proto3 field, or annotated with `@Required`. |
 
 ### Per message annotation
 
-| annotation | description 	                                                                                            |
-|------------|:---------------------------------------------------------------------------------------------------------|
-| @RootNode  | If there are multiple types without an parent you can give a hint to the root node with this annotation. |
+| annotation | description |
+|------------|:------------|
+| @RootNode | If there are multiple types without a parent, you can give a hint about the root node with this annotation. |
 
 ### Head annotation
 
-| annotation | description 	                                             |
-|------------|:----------------------------------------------------------|
-| @Option    | In head of your file you can place options for the parser |
-
+| annotation | description |
+|------------|:------------|
+| @Option | In the head of your file you can place options for the parser. |
 
 ### Head annotation "Option"
 
-The `@Option` have to follow by space separated options key and another space separated value 
+The `@Option` has to be followed by a space-separated option key and a space-separated value.
 
-```
+```proto
 // @Option primitiveTypesWithLimits false
 
 message Point {
@@ -177,15 +253,51 @@ message Point {
 
 Possible options are:
 
-
-| option                   | description  	                                                                                             | def  |
-|--------------------------|:-----------------------------------------------------------------------------------------------------------|:-----|
-| primitiveTypesWithLimits | If you dont like to get default Min and Max limits for primitive types, you can set this option to `false` | true |
+| option | description | default |
+|--------|:------------|:--------|
+| primitiveTypesWithLimits | If you do not want default `minimum`/`maximum` limits for primitive types, set this option to `false`. | true |
 
 ## Supported validation frameworks
 
-If you would like to add additional validation to your proto files, you can use one of the following validation frameworks.
+If you would like to add additional validation to your proto files, you can use one of the following
+validation frameworks. Their rules are translated into JSON Schema validation keywords during
+parsing.
 
-- [proto-gen-validate](https://github.com/bufbuild/protoc-gen-validate) Validation of lists are not 100% supported
-- [protovalid](https://github.com/bufbuild/protovalidate)
+- [protoc-gen-validate](https://github.com/bufbuild/protoc-gen-validate) — validation of lists is not
+  100% supported.
+- [protovalidate](https://github.com/bufbuild/protovalidate)
 
+## Development
+
+This project is written in TypeScript and builds both an ES module (`esm/`) and a CommonJS (`cjs/`)
+output. Tests use [Jest](https://jestjs.io/) against snapshot-style fixtures in `test/documents`.
+
+```sh
+npm install          # install dependencies
+
+npm run build        # build both esm/ and cjs/ (build:esm, build:cjs)
+npm test             # run the Jest test suite with coverage
+npm run lint         # run ESLint (use lint:fix to auto-fix)
+```
+
+Source layout:
+
+| Path | Purpose |
+|------|---------|
+| `src/index.ts` | Parser factory; implements the `@asyncapi/parser` schema-parser contract (`parse`, `validate`, `getMimeTypes`). |
+| `src/protoj2jsonSchema.ts` | Core converter that turns a Protobuf schema into an AsyncAPI schema. |
+| `src/primitive-types.ts` | Scalar Protobuf type to JSON Schema `type`/`format` map. |
+| `src/google-types.ts` | Bundled `google/type/*` well-known definitions. |
+| `src/pathUtils.ts` | Import path resolution helpers. |
+| `src/protoc-gen-validate.ts` | Maps `(validate.rules)` options to JSON Schema validators. |
+| `src/protovalidate.ts` | Maps `(buf.validate.field)` options to JSON Schema validators. |
+| `test/documents/*.yaml` | AsyncAPI input fixtures; `*.result.json` are the expected parsed outputs. |
+
+## Contributing
+
+Read [CONTRIBUTING](./CONTRIBUTING.md) to learn about the contribution process and the AsyncAPI
+[Code of Conduct](./CODE_OF_CONDUCT.md). Issues and pull requests are welcome.
+
+## License
+
+[Apache-2.0](./LICENSE)


### PR DESCRIPTION
## Summary
Documentation-only update: reworks the README into a clearer, task-oriented structure and adds an `AGENTS.md` contributor/agent guide. No code changes.

### README
- Restructured: Overview, Installation, Usage (ESM + CJS registration and a parse example), Supported input, How it works (the Protobuf → AsyncAPI mapping, root selection, `x-` keywords), Scalar type formats, Comments & annotations, Supported validation frameworks, Development.
- Preserved existing content: badges, TOC markers, the annotation/option tables, license and contributing.
- Corrected the usage examples — they referenced a non-exported `ProtoSchemaParser`; the package actually exports `ProtoBuffSchemaParser` (verified in `src/index.ts`, the CJS/ESM builds and the tests). Also repointed a stale `@Default` link to the official json-schema.org annotations page.

### AGENTS.md (new)
A contributor / AI-agent guide for this repository: technology stack, project structure, coding standards, the schema-parser contract (integration with `@asyncapi/parser`), the Protobuf → AsyncAPI mapping rules, testing, invariants, and a worked example.
