### PR TITLE
fix: a field comment must not extend the comment of the message it re…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,7 +96,9 @@ walks the tree. Core rules:
   `PRIMITIVE_TYPES_MINIMAL` when `primitiveTypesWithLimits` is `false`); sets `type`, `format`,
   `x-primitive`, and numeric `minimum`/`maximum` where defined.
 - **Message-typed field** -> the referenced message compiled inline, plus `x-type` = Protobuf type
-  name.
+  name. A comment on the field replaces the inlined `description` and moves the message's own
+  comment to `x-type-description`, so consumers documenting the type itself never read a field
+  comment.
 - **Enum** -> `{ title, type: 'string', enum: [names], 'x-enum-mapping': { name: number } }`; a field
   referencing an enum also gets `x-type`.
 - **`repeated` field** -> `{ type: 'array', items: <field schema> }`. Supports `@MinItems`/`@MaxItems`
@@ -121,8 +123,9 @@ walks the tree. Core rules:
 `protobufjs`, `google/type/*` via `google-types.ts`, and the two validation `.proto` files). Any
 other `import` throws.
 
-The `x-` keywords (`x-primitive`, `x-type`, `x-enum-mapping`, `x-oneof-item`) are an intentional part
-of the output. Do not remove or rename them without treating it as a breaking change.
+The `x-` keywords (`x-primitive`, `x-type`, `x-type-description`, `x-enum-mapping`, `x-oneof-item`)
+are an intentional part of the output. Do not remove or rename them without treating it as a
+breaking change.
 
 ## 6. Testing
 

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The main mapping rules:
 | `enum` | `{ "type": "string", "enum": [<names>], "x-enum-mapping": { <name>: <number> } }` |
 | `repeated` field | `{ "type": "array", "items": <field schema> }` |
 | `oneof` with 2+ members | A property named after the `oneof` holding `{ "oneOf": [ ... ] }`; each variant carries `x-oneof-item` with the field name |
-| Field / message comment | `description` (with `@`-annotations stripped out) |
+| Field / message comment | `description` (with `@`-annotations stripped out). A field comment replaces the comment of the message it references, which moves to `x-type-description` |
 
 Field membership in the `required` list is additive: a field is marked required if it is proto2
 `required`, a non-optional proto3 field, or annotated with `@Required`.
@@ -172,6 +172,7 @@ branch, the converter stops descending to avoid an infinite loop.
 
 Non-standard (`x-`) keywords are used to preserve Protobuf information that has no direct JSON Schema
 equivalent: `x-primitive` (original scalar type), `x-type` (referenced message/enum name),
+`x-type-description` (comment of the referenced message when a field comment replaced it),
 `x-enum-mapping` (enum name to numeric value), and `x-oneof-item` (the `oneof` field a variant came
 from).
 

--- a/src/protoj2jsonSchema.ts
+++ b/src/protoj2jsonSchema.ts
@@ -403,10 +403,9 @@ class Proto2JsonSchema {
     const desc = this.extractDescription(field.comment);
     if (desc !== null && desc.length > 0) {
       if (obj.description) {
-        obj.description = (`${desc}\n${obj.description}`).trim();
-      } else {
-        obj.description = desc;
+        obj['x-type-description'] = obj.description;
       }
+      obj.description = desc;
     }
 
     const examples = this.extractExamples(field.comment);

--- a/test/documents/comments.proto.result.json
+++ b/test/documents/comments.proto.result.json
@@ -75,8 +75,9 @@
                     "x-primitive": "string"
                   }
                 },
-                "description": "field comment A\nSingle-line comment",
-                "x-type": "Point"
+                "description": "field comment A",
+                "x-type": "Point",
+                "x-type-description": "Single-line comment"
               },
               "label": {
                 "type": "string",
@@ -176,8 +177,9 @@
                   "x-primitive": "string"
                 }
               },
-              "description": "field comment A\nSingle-line comment",
-              "x-type": "Point"
+              "description": "field comment A",
+              "x-type": "Point",
+              "x-type-description": "Single-line comment"
             },
             "label": {
               "type": "string",

--- a/test/documents/shared-message-type.proto.result.json
+++ b/test/documents/shared-message-type.proto.result.json
@@ -1,0 +1,161 @@
+{
+  "asyncapi": "2.0.0",
+  "info": {
+    "title": "Example using the same ProtoBuff message type for several fields",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "mychannel": {
+      "publish": {
+        "message": {
+          "schemaFormat": "application/vnd.google.protobuf;version=3",
+          "payload": {
+            "title": "TrainRunExecutionDifference",
+            "type": "object",
+            "required": [
+              "passed_positions"
+            ],
+            "properties": {
+              "origin": {
+                "title": "ZnvOccupancy",
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "string",
+                    "x-primitive": "string",
+                    "description": "Name of the Iltis element."
+                  }
+                },
+                "description": "Origin position.",
+                "x-type": "ZnvOccupancy",
+                "x-type-description": "Data type for a ZnvOccupancy"
+              },
+              "deletion_position": {
+                "title": "ZnvOccupancy",
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "string",
+                    "x-primitive": "string",
+                    "description": "Name of the Iltis element."
+                  }
+                },
+                "description": "Position at which the train number is deleted.",
+                "x-type": "ZnvOccupancy",
+                "x-type-description": "Data type for a ZnvOccupancy"
+              },
+              "uncommented_position": {
+                "title": "ZnvOccupancy",
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "string",
+                    "x-primitive": "string",
+                    "description": "Name of the Iltis element."
+                  }
+                },
+                "description": "Data type for a ZnvOccupancy",
+                "x-type": "ZnvOccupancy"
+              },
+              "passed_positions": {
+                "type": "array",
+                "items": {
+                  "title": "ZnvOccupancy",
+                  "type": "object",
+                  "properties": {
+                    "element": {
+                      "type": "string",
+                      "x-primitive": "string",
+                      "description": "Name of the Iltis element."
+                    }
+                  },
+                  "description": "All positions the train passed.",
+                  "x-type": "ZnvOccupancy",
+                  "x-type-description": "Data type for a ZnvOccupancy"
+                },
+                "description": "All positions the train passed."
+              }
+            },
+            "description": "Difference between the planned and the executed train run"
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "messages": {
+      "testMessage": {
+        "schemaFormat": "application/vnd.google.protobuf;version=3",
+        "payload": {
+          "title": "TrainRunExecutionDifference",
+          "type": "object",
+          "required": [
+            "passed_positions"
+          ],
+          "properties": {
+            "origin": {
+              "title": "ZnvOccupancy",
+              "type": "object",
+              "properties": {
+                "element": {
+                  "type": "string",
+                  "x-primitive": "string",
+                  "description": "Name of the Iltis element."
+                }
+              },
+              "description": "Origin position.",
+              "x-type": "ZnvOccupancy",
+              "x-type-description": "Data type for a ZnvOccupancy"
+            },
+            "deletion_position": {
+              "title": "ZnvOccupancy",
+              "type": "object",
+              "properties": {
+                "element": {
+                  "type": "string",
+                  "x-primitive": "string",
+                  "description": "Name of the Iltis element."
+                }
+              },
+              "description": "Position at which the train number is deleted.",
+              "x-type": "ZnvOccupancy",
+              "x-type-description": "Data type for a ZnvOccupancy"
+            },
+            "uncommented_position": {
+              "title": "ZnvOccupancy",
+              "type": "object",
+              "properties": {
+                "element": {
+                  "type": "string",
+                  "x-primitive": "string",
+                  "description": "Name of the Iltis element."
+                }
+              },
+              "description": "Data type for a ZnvOccupancy",
+              "x-type": "ZnvOccupancy"
+            },
+            "passed_positions": {
+              "type": "array",
+              "items": {
+                "title": "ZnvOccupancy",
+                "type": "object",
+                "properties": {
+                  "element": {
+                    "type": "string",
+                    "x-primitive": "string",
+                    "description": "Name of the Iltis element."
+                  }
+                },
+                "description": "All positions the train passed.",
+                "x-type": "ZnvOccupancy",
+                "x-type-description": "Data type for a ZnvOccupancy"
+              },
+              "description": "All positions the train passed."
+            }
+          },
+          "description": "Difference between the planned and the executed train run"
+        }
+      }
+    }
+  }
+}

--- a/test/documents/shared-message-type.proto.yaml
+++ b/test/documents/shared-message-type.proto.yaml
@@ -1,0 +1,36 @@
+asyncapi: 2.0.0
+info:
+  title: Example using the same ProtoBuff message type for several fields
+  version: '1.0.0'
+channels:
+  mychannel:
+    publish:
+      message:
+        $ref: '#/components/messages/testMessage'
+
+components:
+  messages:
+    testMessage:
+      schemaFormat: 'application/vnd.google.protobuf;version=3'
+      payload: |
+        syntax = "proto3";
+
+        // Data type for a ZnvOccupancy
+        message ZnvOccupancy {
+            // Name of the Iltis element.
+            optional string element = 1;
+        }
+
+        // Difference between the planned and the executed train run
+        message TrainRunExecutionDifference {
+            // Origin position.
+            optional ZnvOccupancy origin = 1;
+
+            // Position at which the train number is deleted.
+            optional ZnvOccupancy deletion_position = 2;
+
+            optional ZnvOccupancy uncommented_position = 3;
+
+            // All positions the train passed.
+            repeated ZnvOccupancy passed_positions = 4;
+        }

--- a/test/parser.spec.ts
+++ b/test/parser.spec.ts
@@ -230,6 +230,34 @@ describe('parse()', function () {
     );
   });
 
+  it('a field comment should replace and not extend the comment of the message it references', async function () {
+    const document = await parseSpec('./documents/shared-message-type.proto.yaml');
+
+    if (UPDATE_RESULTS) {
+      writeResults(
+        document,
+        './documents/shared-message-type.proto.result.json'
+      );
+    }
+
+    expect(
+      stripParserExtraInfos(document?.json())
+    ).toEqual(
+      readResultFile('./documents/shared-message-type.proto.result.json')
+    );
+
+    const properties = document?.json().components.messages.testMessage.payload.properties;
+
+    expect(properties.origin.description).toEqual('Origin position.');
+    expect(properties.deletion_position.description).toEqual('Position at which the train number is deleted.');
+    expect(properties.uncommented_position.description).toEqual('Data type for a ZnvOccupancy');
+    expect(properties.passed_positions.description).toEqual('All positions the train passed.');
+
+    expect(properties.origin['x-type-description']).toEqual('Data type for a ZnvOccupancy');
+    expect(properties.deletion_position['x-type-description']).toEqual('Data type for a ZnvOccupancy');
+    expect(properties.passed_positions.items['x-type-description']).toEqual('Data type for a ZnvOccupancy');
+  });
+
   function filterDiagnostics(diagnostics: Diagnostic[], code: string) {
     return diagnostics.filter((d) => d.code === code);
   }


### PR DESCRIPTION
…ferences

A field whose type is a message inherited the compiled message schema and then prepended its own comment to the message comment. Both descriptions ended up in a single string, so a consumer rendering the property read the type description as part of the field description, and a consumer rendering the type read the comment of whichever field it happened to compile last.

The field comment now replaces the inherited description and the comment of the referenced message moves to `x-type-description`, so both descriptions stay separately addressable.

STTRS-3061

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->