### PR TITLE
feat: publish pending comment fix and restore release workflow

### DIFF
--- a/.github/workflows/if-nodejs-release.yml
+++ b/.github/workflows/if-nodejs-release.yml
@@ -30,8 +30,7 @@ jobs:
       (startsWith( github.event.commits[0].message , 'fix:' ) ||
       startsWith( github.event.commits[0].message, 'fix!:' ) ||
       startsWith( github.event.commits[0].message, 'feat:' ) ||
-      startsWith( github.event.commits[0].message, 'feat!:' )) ||
-      startsWith( github.event.commits[0].message, 'chore(release)!:' ))
+      startsWith( github.event.commits[0].message, 'feat!:' ))
     name: Test NodeJS release on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
Restores .github/workflows/if-nodejs-release.yml to the centrally managed version, reverting the `if:` change from #165. That change added a `chore(release)!:` clause but left an unbalanced closing parenthesis, making the workflow expression invalid - GitHub cannot parse the file, so every push to master start-fails with zero jobs and no release can run. This file is centrally managed in asyncapi/.github and must not be patched here.

Marked `feat:` on purpose so semantic-release cuts 3.9.0 from 3.8.3. The fix from #163 is on master but was never published: its release run was made obsolete when #162 was merged ~1 minute later, so semantic-release found the branch behind the remote and exited without publishing. npm is still on 3.8.3.

Do not merge anything else to master until the release job for this PR has finished, or the same thing will happen again.

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- ...
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->